### PR TITLE
[Feat] CORS 설정을 위한 Filter 추가

### DIFF
--- a/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/global/config/filter/CorsFilter.java
+++ b/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/global/config/filter/CorsFilter.java
@@ -1,0 +1,44 @@
+package softeer.bemycarmaster.api.global.config.filter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CorsFilter implements Filter {
+
+	private final List<String> allowedOrigins = Arrays.asList("http://h5-my-car-master.vercel.app");
+
+	@Override
+	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws
+		IOException,
+		ServletException {
+
+		HttpServletResponse response = (HttpServletResponse)res;
+		HttpServletRequest request = (HttpServletRequest)req;
+		String origin = request.getHeader("Origin");
+
+		setCorsHeader(response, origin);
+
+		chain.doFilter(req, res);
+	}
+
+	private void setCorsHeader(HttpServletResponse response, String origin) {
+		if (allowedOrigins.contains(origin)) {
+			response.setHeader("Access-Control-Allow-Origin", origin);
+			response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+			response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+			response.setHeader("Access-Control-Allow-Credentials", "true");
+		}
+	}
+}


### PR DESCRIPTION
## 개요
- #42 

## 작업사항
- allowedOrigins에 해당하는 Origin에서 요청시 CorsFilter에서 응답 Header에 관련 설정 추가.
- FE 로컬 환경에 대한 Origin 설정 추가 필요.

## 고민사항
- CORS 처리를 위한 기술로 Interceptor 와 Filter 두 가지를 고려. 단순히 CORS 처리만 해주면 되기에 스프링에 종속적인 Interceptor 보다는 Filter를 사용하여 처리하기로 결정. 
