### PR TITLE
[Setting] SwiftLint disabled rule 추가

### DIFF
--- a/iOS-MyCarMaster/MyCarMaster/.swiftlint.yml
+++ b/iOS-MyCarMaster/MyCarMaster/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
   - nesting
   - file_types_order
+  - trailing_comma
 
 opt_in_rules:
   - empty_count


### PR DESCRIPTION
## 개요

## 작업사항
- SwiftLint disabled rule 추가
- 배열의 원소를 선언할 때, 마지막 원소에 `,`를 붙일 수 있도록 룰 수정.
  - 새로운 원소가 추가됐을 때, diff가 한 줄로 표시되기 위함.

예)
기존
```diff
let arr = [
+  image1,
+  image2
]
```
이후
```diff
let arr = [
   image1,
+  image2,
]
```

## 고민사항
- 없음
