### PR TITLE
[Feature] 엔진에 변경 따라 선택불가능해지는 옵션 목록 조회 예외 처리 로직 추가

### DIFF
--- a/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/domain/engine/controller/EngineController.java
+++ b/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/domain/engine/controller/EngineController.java
@@ -42,7 +42,7 @@ public class EngineController {
 	@Operation(summary = "엔진 변경 시도시 기존에 선택된 옵션들 중 변경하려는 엔진에서 선택 불가능한 옵션 목록을 반환합니다.")
 	public Response<GetUnselectableOptionsByEngineResponse> getUnselectableOptionsByEngine(
 		@PathVariable Long engineId,
-		@RequestBody GetUnselectableOptionsByEngineRequest getUnselectableOptionsByEngineRequest
+		@RequestBody @Valid GetUnselectableOptionsByEngineRequest getUnselectableOptionsByEngineRequest
 	) {
 		Long trimId = getUnselectableOptionsByEngineRequest.getTrimId();
 		List<Long> optionIds = getUnselectableOptionsByEngineRequest.getOptionsIds();

--- a/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/domain/engine/dto/request/GetUnselectableOptionsByEngineRequest.java
+++ b/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/domain/engine/dto/request/GetUnselectableOptionsByEngineRequest.java
@@ -2,6 +2,10 @@ package softeer.bemycarmaster.api.domain.engine.dto.request;
 
 import java.util.List;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,8 +19,11 @@ import lombok.Setter;
 public class GetUnselectableOptionsByEngineRequest {
 
 	@Schema(description = "트림 식별자", example = "1")
+	@NotNull(message = "trimId는 Null일 수 없습니다.")
+	@Min(value = 1, message = "trimId는 1 이상의 값입니다.")
 	private Long trimId;
 
 	@Schema(description = "기존에 선택된 옵션 식별자 목록", example = "[1, 2, 3]")
+	@NotEmpty(message = "옵션 식별자 목록은 비어있을 수 없습니다.")
 	private List<Long> optionsIds;
 }

--- a/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/domain/engine/dto/response/UnselectableOptionDto.java
+++ b/BE-MyCarMaster/src/main/java/softeer/bemycarmaster/api/domain/engine/dto/response/UnselectableOptionDto.java
@@ -1,11 +1,16 @@
 package softeer.bemycarmaster.api.domain.engine.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UnselectableOptionDto {
 	@Schema(description = "옵션 식별자", example = "1")
 	private Long id;


### PR DESCRIPTION
## 개요
- #17 

## 작업사항
- 트림 목록 조회 예외 처리 로직 추가
- 트림 목록 조회 TC 작성

## 고민사항
- EngineControllerTest가 너무 길어지는 것 같은데, 그냥 Controller를 분리하는게 더 나으려나..