### PR TITLE
[Feature] 외장 색상 목록 조회 구현

### DIFF
--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/controller/ExteriorColorController.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/controller/ExteriorColorController.java
@@ -25,8 +25,7 @@ public class ExteriorColorController {
 	@Operation(summary = "트림에서 선택가능한 외장 색상 목록을 반환합니다")
 	public Response<GetExteriorColorsResponse> getExteriorColors(
 		@RequestBody @Valid GetExteriorColorsRequest getExteriorColorsRequest) {
-
-		Integer trimId = getExteriorColorsRequest.getTrimId();
+		Long trimId = getExteriorColorsRequest.getTrimId();
 		GetExteriorColorsResponse getExteriorColorsResponse = getExteriorColorsUseCase.execute(trimId);
 		return Response.createSuccessResponse(getExteriorColorsResponse);
 	}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/dto/request/GetExteriorColorsRequest.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/dto/request/GetExteriorColorsRequest.java
@@ -18,5 +18,5 @@ public class GetExteriorColorsRequest {
 	@Schema(description = "트림 식별자", example = "1")
 	@NotNull(message = "trimId는 Null 일 수 없습니다.")
 	@Min(value = 1, message = "trimId는 1 이상의 값입니다.")
-	private Integer trimId;
+	private Long trimId;
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/dto/response/ExteriorColorDto.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/dto/response/ExteriorColorDto.java
@@ -1,19 +1,21 @@
 package softeer.be_my_car_master.api.color_exterior.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
 
 @Getter
 @Setter
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExteriorColorDto {
 
 	@Schema(description = "외장 색상 식별자", example = "1")
-	private Integer id;
+	private Long id;
 
 	@Schema(description = "외장 색상명", example = "그라파이트 그레이 메탈릭")
 	private String name;
@@ -29,4 +31,16 @@ public class ExteriorColorDto {
 
 	@Schema(description = "외장 색상이 적용된 차량 이미지", example = "coloredImgUrl")
 	private String coloredImgUrl;
+
+	public static ExteriorColorDto from(ExteriorColor exteriorColor) {
+		return ExteriorColorDto.builder()
+			.id(exteriorColor.getId())
+			.name(exteriorColor.getName())
+			.price(exteriorColor.getPrice())
+			.ratio(exteriorColor.getRatio())
+			.colorImgUrl(exteriorColor.getColorImgUrl())
+			.coloredImgUrl(exteriorColor.getColoredImgUrl())
+			.build();
+	}
 }
+

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/dto/response/GetExteriorColorsResponse.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/dto/response/GetExteriorColorsResponse.java
@@ -1,13 +1,27 @@
 package softeer.be_my_car_master.api.color_exterior.dto.response;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetExteriorColorsResponse {
 
 	private List<ExteriorColorDto> colors;
+
+	public static GetExteriorColorsResponse from(List<ExteriorColor> selectableColors) {
+		List<ExteriorColorDto> exteriorColorDtos = selectableColors.stream()
+			.map(ExteriorColorDto::from)
+			.collect(Collectors.toList());
+		return new GetExteriorColorsResponse(exteriorColorDtos);
+	}
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/usecase/GetExteriorColorsUseCase.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/usecase/GetExteriorColorsUseCase.java
@@ -1,12 +1,21 @@
 package softeer.be_my_car_master.api.color_exterior.usecase;
 
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
 import softeer.be_my_car_master.api.color_exterior.dto.response.GetExteriorColorsResponse;
+import softeer.be_my_car_master.api.color_exterior.usecase.port.ExteriorColorPort;
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
 import softeer.be_my_car_master.global.annotation.UseCase;
 
 @UseCase
+@RequiredArgsConstructor
 public class GetExteriorColorsUseCase {
 
-	public GetExteriorColorsResponse execute(Integer trimId) {
-		return new GetExteriorColorsResponse();
+	private final ExteriorColorPort exteriorColorPort;
+
+	public GetExteriorColorsResponse execute(Long trimId) {
+		List<ExteriorColor> exteriorColors = exteriorColorPort.findSelectableExteriorColorsByTrimId(trimId);
+		return GetExteriorColorsResponse.from(exteriorColors);
 	}
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/usecase/port/ExteriorColorPort.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/color_exterior/usecase/port/ExteriorColorPort.java
@@ -1,0 +1,12 @@
+package softeer.be_my_car_master.api.color_exterior.usecase.port;
+
+import java.util.List;
+
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
+import softeer.be_my_car_master.global.annotation.Port;
+
+@Port
+public interface ExteriorColorPort {
+
+	List<ExteriorColor> findSelectableExteriorColorsByTrimId(Long trimId);
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/color_exterior/ExteriorColor.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/color_exterior/ExteriorColor.java
@@ -1,0 +1,31 @@
+package softeer.be_my_car_master.domain.color_exterior;
+
+import java.util.Set;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import softeer.be_my_car_master.global.annotation.Domain;
+
+@Domain
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExteriorColor {
+
+	private Long id;
+	private String name;
+	private Integer price;
+	private Integer ratio;
+	private String colorImgUrl;
+	private String coloredImgUrl;
+
+	public Long getId() {
+		return id;
+	}
+
+	public Boolean isUnselectable(Set<Long> unselectableColorIds) {
+		return !unselectableColorIds.contains(id);
+	}
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/model/Model.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/model/Model.java
@@ -3,7 +3,9 @@ package softeer.be_my_car_master.domain.model;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import softeer.be_my_car_master.global.annotation.Domain;
 
+@Domain
 @Getter
 @Builder
 @AllArgsConstructor

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/trim/Trim.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/trim/Trim.java
@@ -3,7 +3,9 @@ package softeer.be_my_car_master.domain.trim;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import softeer.be_my_car_master.global.annotation.Domain;
 
+@Domain
 @Getter
 @Builder
 @AllArgsConstructor

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/annotation/Domain.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/annotation/Domain.java
@@ -1,0 +1,8 @@
+package softeer.be_my_car_master.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+public @interface Domain {
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/adaptor/ExteriorColorJpaAdaptor.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/adaptor/ExteriorColorJpaAdaptor.java
@@ -1,0 +1,25 @@
+package softeer.be_my_car_master.infrastructure.jpa.color_exterior.adaptor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+import softeer.be_my_car_master.api.color_exterior.usecase.port.ExteriorColorPort;
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
+import softeer.be_my_car_master.global.annotation.Adaptor;
+import softeer.be_my_car_master.infrastructure.jpa.color_exterior.entity.TrimExteriorColorEntity;
+import softeer.be_my_car_master.infrastructure.jpa.color_exterior.repository.TrimExteriorColorJpaRepository;
+
+@Adaptor
+@RequiredArgsConstructor
+public class ExteriorColorJpaAdaptor implements ExteriorColorPort {
+
+	private final TrimExteriorColorJpaRepository trimExteriorColorJpaRepository;
+
+	@Override
+	public List<ExteriorColor> findSelectableExteriorColorsByTrimId(Long trimId) {
+		return trimExteriorColorJpaRepository.findAllByTrimId(trimId).stream()
+			.map(TrimExteriorColorEntity::toExteriorColor)
+			.collect(Collectors.toList());
+	}
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/entity/ExteriorColorEntity.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/entity/ExteriorColorEntity.java
@@ -1,0 +1,38 @@
+package softeer.be_my_car_master.infrastructure.jpa.color_exterior.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
+
+@Entity
+@Table(name = "exterior_color")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExteriorColorEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "color_img_url", nullable = false)
+	private String colorImgUrl;
+
+	public ExteriorColor toExteriorColor() {
+		return ExteriorColor.builder()
+			.id(id)
+			.name(name)
+			.colorImgUrl(colorImgUrl)
+			.build();
+	}
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/entity/TrimExteriorColorEntity.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/entity/TrimExteriorColorEntity.java
@@ -1,0 +1,49 @@
+package softeer.be_my_car_master.infrastructure.jpa.color_exterior.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
+import softeer.be_my_car_master.infrastructure.jpa.trim.entity.TrimEntity;
+
+@Entity
+public class TrimExteriorColorEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+
+	@Column(name = "ratio", nullable = false)
+	private Integer ratio;
+
+	@Column(name = "price", nullable = false)
+	private Integer price;
+
+	@Column(name = "colored_car_img_url", nullable = false)
+	private String coloredCarImgUrl;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "trim_id")
+	private TrimEntity trim;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "exterior_color_id")
+	private ExteriorColorEntity exteriorColor;
+
+	public ExteriorColor toExteriorColor() {
+		return ExteriorColor.builder()
+			.id(exteriorColor.getId())
+			.name(exteriorColor.getName())
+			.ratio(ratio)
+			.price(price)
+			.colorImgUrl(exteriorColor.getColorImgUrl())
+			.coloredImgUrl(coloredCarImgUrl)
+			.build();
+	}
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/repository/TrimExteriorColorJpaRepository.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/color_exterior/repository/TrimExteriorColorJpaRepository.java
@@ -1,0 +1,17 @@
+package softeer.be_my_car_master.infrastructure.jpa.color_exterior.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import softeer.be_my_car_master.infrastructure.jpa.color_exterior.entity.TrimExteriorColorEntity;
+
+public interface TrimExteriorColorJpaRepository extends JpaRepository<TrimExteriorColorEntity, Long> {
+
+	@Query(value = "SELECT tec "
+		+ "FROM TrimExteriorColorEntity tec "
+		+ "JOIN FETCH tec.exteriorColor "
+		+ "WHERE tec.trim.id = :trimId")
+	List<TrimExteriorColorEntity> findAllByTrimId(Long trimId);
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/model/adaptor/ModelJpaAdaptor.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/model/adaptor/ModelJpaAdaptor.java
@@ -1,4 +1,4 @@
-package softeer.be_my_car_master.infrastructure.model;
+package softeer.be_my_car_master.infrastructure.jpa.model.adaptor;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import softeer.be_my_car_master.api.model.usecase.port.ModelPort;
 import softeer.be_my_car_master.domain.model.Model;
 import softeer.be_my_car_master.global.annotation.Adaptor;
+import softeer.be_my_car_master.infrastructure.jpa.model.entity.ModelEntity;
+import softeer.be_my_car_master.infrastructure.jpa.model.repository.ModelJpaRepository;
 
 @Adaptor
 @RequiredArgsConstructor

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/model/entity/ModelEntity.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/model/entity/ModelEntity.java
@@ -1,4 +1,4 @@
-package softeer.be_my_car_master.infrastructure.model;
+package softeer.be_my_car_master.infrastructure.jpa.model.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/model/repository/ModelJpaRepository.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/model/repository/ModelJpaRepository.java
@@ -1,0 +1,8 @@
+package softeer.be_my_car_master.infrastructure.jpa.model.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import softeer.be_my_car_master.infrastructure.jpa.model.entity.ModelEntity;
+
+public interface ModelJpaRepository extends JpaRepository<ModelEntity, Long> {
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/trim/adaptor/TrimJpaAdaptor.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/trim/adaptor/TrimJpaAdaptor.java
@@ -1,4 +1,4 @@
-package softeer.be_my_car_master.infrastructure.trim;
+package softeer.be_my_car_master.infrastructure.jpa.trim.adaptor;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import softeer.be_my_car_master.api.trim.usecase.port.TrimPort;
 import softeer.be_my_car_master.domain.trim.Trim;
 import softeer.be_my_car_master.global.annotation.Adaptor;
+import softeer.be_my_car_master.infrastructure.jpa.trim.entity.TrimEntity;
+import softeer.be_my_car_master.infrastructure.jpa.trim.repository.TrimJpaRepository;
 
 @Adaptor
 @RequiredArgsConstructor

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/trim/entity/TrimEntity.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/trim/entity/TrimEntity.java
@@ -1,4 +1,4 @@
-package softeer.be_my_car_master.infrastructure.trim;
+package softeer.be_my_car_master.infrastructure.jpa.trim.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,7 +13,7 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import softeer.be_my_car_master.domain.trim.Trim;
-import softeer.be_my_car_master.infrastructure.model.ModelEntity;
+import softeer.be_my_car_master.infrastructure.jpa.model.entity.ModelEntity;
 
 @Entity
 @Table(name = "trim")

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/trim/repository/TrimJpaRepository.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/trim/repository/TrimJpaRepository.java
@@ -1,9 +1,11 @@
-package softeer.be_my_car_master.infrastructure.trim;
+package softeer.be_my_car_master.infrastructure.jpa.trim.repository;
 
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import softeer.be_my_car_master.infrastructure.jpa.trim.entity.TrimEntity;
 
 public interface TrimJpaRepository extends JpaRepository<TrimEntity, Long> {
 

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/model/ModelJpaRepository.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/model/ModelJpaRepository.java
@@ -1,6 +1,0 @@
-package softeer.be_my_car_master.infrastructure.model;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ModelJpaRepository extends JpaRepository<ModelEntity, Long> {
-}

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/color_exterior/controller/ExteriorColorControllerTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/color_exterior/controller/ExteriorColorControllerTest.java
@@ -40,11 +40,11 @@ class ExteriorColorControllerTest {
 	@DisplayName("외장 색상 목록을 조회합니다")
 	void getExteriorColors() throws Exception {
 		//given
-		String requestBody = getRequestBody(new GetExteriorColorsRequest(1));
+		String requestBody = getRequestBody(new GetExteriorColorsRequest(1L));
 
 		GetExteriorColorsResponse getExteriorColorsResponse = new GetExteriorColorsResponse();
 		ExteriorColorDto exteriorColorDto = ExteriorColorDto.builder()
-			.id(1)
+			.id(1L)
 			.name("Exterior Color")
 			.price(0)
 			.ratio(32)
@@ -76,7 +76,7 @@ class ExteriorColorControllerTest {
 	@DisplayName("trimId는 1 이상이어야 합니다")
 	void minimumTrimId() throws Exception {
 		//given
-		String requestBody = getRequestBody(new GetExteriorColorsRequest(0));
+		String requestBody = getRequestBody(new GetExteriorColorsRequest(0L));
 
 		String responseBody = getClientErrorResponseBody();
 

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/color_exterior/usecase/GetExteriorColorsUseCaseTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/color_exterior/usecase/GetExteriorColorsUseCaseTest.java
@@ -30,7 +30,7 @@ class GetExteriorColorsUseCaseTest {
 	private ExteriorColorPort exteriorColorPort;
 
 	@Test
-	@DisplayName("모델 목록을 조회합니다")
+	@DisplayName("외장 색상 목록을 조회합니다")
 	void execute() {
 		// given
 		ExteriorColor exteriorColor = ExteriorColor.builder()

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/color_exterior/usecase/GetExteriorColorsUseCaseTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/color_exterior/usecase/GetExteriorColorsUseCaseTest.java
@@ -1,0 +1,63 @@
+package softeer.be_my_car_master.api.color_exterior.usecase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import softeer.be_my_car_master.api.color_exterior.dto.response.ExteriorColorDto;
+import softeer.be_my_car_master.api.color_exterior.dto.response.GetExteriorColorsResponse;
+import softeer.be_my_car_master.api.color_exterior.usecase.port.ExteriorColorPort;
+import softeer.be_my_car_master.domain.color_exterior.ExteriorColor;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetExteriorColorsUseCase Test")
+class GetExteriorColorsUseCaseTest {
+
+	@InjectMocks
+	private GetExteriorColorsUseCase getExteriorColorsUseCase;
+
+	@Mock
+	private ExteriorColorPort exteriorColorPort;
+
+	@Test
+	@DisplayName("모델 목록을 조회합니다")
+	void execute() {
+		// given
+		ExteriorColor exteriorColor = ExteriorColor.builder()
+			.id(1L)
+			.name("blue")
+			.price(10000)
+			.ratio(22)
+			.colorImgUrl("colorImgUrl")
+			.coloredImgUrl("coloredImgUrl")
+			.build();
+		given(exteriorColorPort.findSelectableExteriorColorsByTrimId(any())).willReturn(Arrays.asList(exteriorColor));
+
+		// when
+		GetExteriorColorsResponse getExteriorColorsResponse = getExteriorColorsUseCase.execute(1L);
+
+		// then
+		List<ExteriorColorDto> exteriorColors = getExteriorColorsResponse.getColors();
+		ExteriorColorDto expected = exteriorColors.get(0);
+
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(exteriorColors).isNotNull();
+			softAssertions.assertThat(exteriorColors).hasSize(1);
+			softAssertions.assertThat(expected.getId()).isEqualTo(exteriorColor.getId());
+			softAssertions.assertThat(expected.getPrice()).isEqualTo(exteriorColor.getPrice());
+			softAssertions.assertThat(expected.getRatio()).isEqualTo(exteriorColor.getRatio());
+			softAssertions.assertThat(expected.getColorImgUrl()).isEqualTo(exteriorColor.getColorImgUrl());
+			softAssertions.assertThat(expected.getColoredImgUrl()).isEqualTo(exteriorColor.getColoredImgUrl());
+		});
+	}
+}


### PR DESCRIPTION
## 개요
- #22 

## 작업사항
- 외장 색상 목록 조회 구현
- TrimExteriorColor 와 같은 매핑 테이블에는 ExteriorColorAdaptor(중심이 되는 도메인) 을 통해서 접근하는 방식으로 결정.

## 고민사항
- 현재는 단순 조회 및 생성 로직 밖에 존재하지 않아 문제가 되지 않지만, 후에 추가적인 요구사항이 생겼을때도 동일한 방식으로 처리할 수 있을지가 고민이다.
- 일단은 현재 구조로 가져가되, 추후 문제 상황 발생시 재논의
