### PR TITLE
[Feature] 엔진 변경에 따라 선택불가능해지는 옵션 목록 조회 구현

### DIFF
--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/dto/response/GetUnselectableOptionsByEngineResponse.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/dto/response/GetUnselectableOptionsByEngineResponse.java
@@ -1,13 +1,27 @@
 package softeer.be_my_car_master.api.engine.dto.response;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import softeer.be_my_car_master.domain.option.Option;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetUnselectableOptionsByEngineResponse {
 
 	private List<UnselectableOptionDto> unselectableOptions;
+
+	public static GetUnselectableOptionsByEngineResponse from(List<Option> unselectableOptionsByEngine) {
+		List<UnselectableOptionDto> unselectableOptionDtos = unselectableOptionsByEngine.stream()
+			.map(UnselectableOptionDto::from)
+			.collect(Collectors.toList());
+		return new GetUnselectableOptionsByEngineResponse(unselectableOptionDtos);
+	}
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/dto/response/UnselectableOptionDto.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/dto/response/UnselectableOptionDto.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import softeer.be_my_car_master.domain.option.Option;
 
 @Getter
 @Setter
@@ -20,4 +21,12 @@ public class UnselectableOptionDto {
 
 	@Schema(description = "옵션 추가 비용", example = "1280000")
 	private Integer price;
+
+	public static UnselectableOptionDto from(Option option) {
+		return UnselectableOptionDto.builder()
+			.id(option.getId())
+			.name(option.getName())
+			.price(option.getPrice())
+			.build();
+	}
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCase.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCase.java
@@ -1,14 +1,33 @@
 package softeer.be_my_car_master.api.engine.usecase;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import lombok.RequiredArgsConstructor;
 import softeer.be_my_car_master.api.engine.dto.response.GetUnselectableOptionsByEngineResponse;
+import softeer.be_my_car_master.api.option.usecase.port.OptionPort;
+import softeer.be_my_car_master.domain.option.Option;
 import softeer.be_my_car_master.global.annotation.UseCase;
 
 @UseCase
+@RequiredArgsConstructor
 public class GetUnselectableOptionsByEngineUseCase {
 
-	public GetUnselectableOptionsByEngineResponse execute(Long engineId, Long trimId, List<Long> optionIds) {
-		return new GetUnselectableOptionsByEngineResponse();
+	private final OptionPort optionPort;
+
+	public GetUnselectableOptionsByEngineResponse execute(Long engineId, Long trimId, List<Long> selectedOptionIds) {
+		List<Option> selectableOptions = optionPort.findSelectableOptionsByTrimId(trimId);
+		List<Long> unselectableOptionIdsByEngine = optionPort.findUnselectableOptionIdsByEngineId(engineId);
+
+		List<Option> unselectableOptionsByEngine = selectableOptions.stream()
+			.filter(option -> isUnselectableOptionByEngine(option, selectedOptionIds, unselectableOptionIdsByEngine))
+			.collect(Collectors.toList());
+
+		return GetUnselectableOptionsByEngineResponse.from(unselectableOptionsByEngine);
+	}
+
+	private static boolean isUnselectableOptionByEngine(Option option, List<Long> selectedOptionIds,
+		List<Long> unselectableOptionIdsByEngine) {
+		return selectedOptionIds.contains(option.getId()) && unselectableOptionIdsByEngine.contains(option.getId());
 	}
 }

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
@@ -1,0 +1,69 @@
+package softeer.be_my_car_master.api.engine.usecase;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import softeer.be_my_car_master.api.engine.dto.response.GetUnselectableOptionsByEngineResponse;
+import softeer.be_my_car_master.api.engine.dto.response.UnselectableOptionDto;
+import softeer.be_my_car_master.api.option.usecase.port.OptionPort;
+import softeer.be_my_car_master.domain.option.Option;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetUnselectableOptionsByEngineUseCase Test")
+class GetUnselectableOptionsByEngineUseCaseTest {
+
+	@InjectMocks
+	private GetUnselectableOptionsByEngineUseCase getUnselectableOptionsByEngineUseCase;
+
+	@Mock
+	private OptionPort optionPort;
+
+	@Test
+	@DisplayName("엔진에 따라 선택 불가능한 옵션 목록을 조회합니다")
+	void execute() {
+		// given
+		Option option = Option.builder()
+			.id(1L)
+			.name("임의의 옵션")
+			.category("SAFE")
+			.summary("옵션 요약")
+			.description("옵션 상세설명")
+			.imgUrl("imgUrl")
+			.price(100000)
+			.ratio(22)
+			.isSuper(false)
+			.subOptions(null)
+			.tag(null)
+			.build();
+
+		given(optionPort.findSelectableOptionsByTrimId(any())).willReturn(Arrays.asList(option));
+		given(optionPort.findUnselectableOptionIdsByEngineId(any())).willReturn(Arrays.asList(2L, 3L));
+
+		// when
+		GetUnselectableOptionsByEngineResponse getUnselectableOptionsByEngineResponse =
+			getUnselectableOptionsByEngineUseCase.execute(1L, 1L, Arrays.asList(1L, 2L));
+
+		// then
+		List<UnselectableOptionDto> options = getUnselectableOptionsByEngineResponse.getUnselectableOptions();
+		UnselectableOptionDto optionExpected = options.get(0);
+
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(options).isNotNull();
+			softAssertions.assertThat(options).hasSize(1);
+			softAssertions.assertThat(optionExpected.getId()).isEqualTo(option.getId());
+			softAssertions.assertThat(optionExpected.getName()).isEqualTo(option.getName());
+			softAssertions.assertThat(optionExpected.getPrice()).isEqualTo(option.getPrice());
+		});
+	}
+}

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
@@ -48,7 +48,7 @@ class GetUnselectableOptionsByEngineUseCaseTest {
 			.build();
 
 		given(optionPort.findSelectableOptionsByTrimId(any())).willReturn(Arrays.asList(option));
-		given(optionPort.findUnselectableOptionIdsByEngineId(any())).willReturn(Arrays.asList(2L, 3L));
+		given(optionPort.findUnselectableOptionIdsByEngineId(any())).willReturn(Arrays.asList(1L, 3L));
 
 		// when
 		GetUnselectableOptionsByEngineResponse getUnselectableOptionsByEngineResponse =


### PR DESCRIPTION
## 개요
- #17 

## 작업사항
- 기존 선택된 옵션 목록 중 엔진 변경에 따라 선택불가능해지는 옵션 목록 조회 기능 구현

## 고민사항
1. engine에서 OptionPort를 갖다써도 되나?
    - 아님 중복되더라도 EnginePort에 같은 내용을 추가해야하나?
    - 일단 그냥 갖다쓰는게 좀 더 맞는 것 같아서 그렇게 함.

2. 옵션 도메인의 이름, 추가비용 정보만 필요하기는 하지만 entity -> domain -> dto로 가야하는거니까 tag를 쓰지 않더라도 그냥 기존처럼 tag까지 fetch join해서 가져오는게 맞는건지, 아님 tag 빼고 가져오는 메소드를 추가해서 tag에 null 넣는 식으로 해야하는건가?
  - 일단 도메인을 완전하게 다 가져와서 거기서 필요한 부분만 쓰는게 더 맞는 것 같다고 생각해서 다 가져오고, domain -> dto에서 이름, 추가비용만 가져와서 쓰도록 함.
