### PR TITLE
[Fix] 엔진 변경에 따라 선택불가능해지는 옵션 목록 조회

### DIFF
--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCase.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCase.java
@@ -8,6 +8,7 @@ import softeer.be_my_car_master.api.engine.dto.response.GetUnselectableOptionsBy
 import softeer.be_my_car_master.api.option.usecase.port.OptionPort;
 import softeer.be_my_car_master.domain.option.Option;
 import softeer.be_my_car_master.global.annotation.UseCase;
+import softeer.be_my_car_master.global.exception.InvalidOptionIdException;
 
 @UseCase
 @RequiredArgsConstructor
@@ -19,15 +20,46 @@ public class GetUnselectableOptionsByEngineUseCase {
 		List<Option> selectableOptions = optionPort.findSelectableOptionsByTrimId(trimId);
 		List<Long> unselectableOptionIdsByEngine = optionPort.findUnselectableOptionIdsByEngineId(engineId);
 
-		List<Option> unselectableOptionsByEngine = selectableOptions.stream()
-			.filter(option -> isUnselectableOptionByEngine(option, selectedOptionIds, unselectableOptionIdsByEngine))
-			.collect(Collectors.toList());
-
+		List<Option> unselectableOptionsByEngine = filterUnselectableOptionsByEngine(
+			selectedOptionIds,
+			selectableOptions,
+			unselectableOptionIdsByEngine
+		);
 		return GetUnselectableOptionsByEngineResponse.from(unselectableOptionsByEngine);
 	}
 
-	private static boolean isUnselectableOptionByEngine(Option option, List<Long> selectedOptionIds,
-		List<Long> unselectableOptionIdsByEngine) {
-		return selectedOptionIds.contains(option.getId()) && unselectableOptionIdsByEngine.contains(option.getId());
+	private List<Option> filterUnselectableOptionsByEngine(
+		List<Long> selectedOptionIds,
+		List<Option> selectableOptions,
+		List<Long> unselectableOptionIdsByEngine
+	) {
+		return selectedOptionIds.stream()
+			.filter(
+				optionId -> isUnselectableOptionByEngine(optionId, selectableOptions, unselectableOptionIdsByEngine)
+			)
+			.map(optionId -> findOptionById(selectableOptions, optionId))
+			.collect(Collectors.toList());
+	}
+
+	private static boolean isUnselectableOptionByEngine(
+		Long optionId,
+		List<Option> selectableOptions,
+		List<Long> unselectableOptionIdsByEngine
+	) {
+		if (!isValidOptionId(optionId, selectableOptions)) {
+			throw new InvalidOptionIdException();
+		}
+		return unselectableOptionIdsByEngine.contains(optionId);
+	}
+
+	private static boolean isValidOptionId(Long optionId, List<Option> selectableOptions) {
+		return selectableOptions.stream().anyMatch(option -> option.getId().equals(optionId));
+	}
+
+	private static Option findOptionById(List<Option> selectableOptions, Long optionId) {
+		return selectableOptions.stream()
+			.filter(option -> option.getId().equals(optionId))
+			.findFirst()
+			.orElseThrow(InvalidOptionIdException::new);
 	}
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/option/usecase/port/OptionPort.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/option/usecase/port/OptionPort.java
@@ -10,6 +10,10 @@ public interface OptionPort {
 
 	List<Option> findSelectableOptionsByTrimId(Long trimId);
 
+	List<Option> findUnselectableOptions(Long trimId, List<Long> optionIds);
+
+	List<Long> findSelectableOptionIdsByTrimId(Long trimId);
+
 	List<Long> findUnselectableOptionIdsByEngineId(Long engineId);
 
 	List<Long> findUnselectableOptionIdsByWheelDriveId(Long wheelDriveId);

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/option/Option.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/domain/option/Option.java
@@ -1,7 +1,6 @@
 package softeer.be_my_car_master.domain.option;
 
 import java.util.List;
-import java.util.Objects;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/InvalidOptionException.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/InvalidOptionException.java
@@ -1,0 +1,11 @@
+package softeer.be_my_car_master.global.exception;
+
+import softeer.be_my_car_master.global.response.ResponseStatus;
+
+public class InvalidOptionException extends MyCarMasterException {
+	public static final MyCarMasterException EXCEPTION = new InvalidOptionException();
+
+	private InvalidOptionException() {
+		super(ResponseStatus.INVALID_OPTION);
+	}
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/InvalidOptionIdException.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/InvalidOptionIdException.java
@@ -1,9 +1,0 @@
-package softeer.be_my_car_master.global.exception;
-
-import softeer.be_my_car_master.global.response.ResponseStatus;
-
-public class InvalidOptionIdException extends MyCarMasterException {
-	public InvalidOptionIdException() {
-		super(ResponseStatus.INVALID_OPTION_ID);
-	}
-}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/InvalidOptionIdException.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/InvalidOptionIdException.java
@@ -1,0 +1,9 @@
+package softeer.be_my_car_master.global.exception;
+
+import softeer.be_my_car_master.global.response.ResponseStatus;
+
+public class InvalidOptionIdException extends MyCarMasterException {
+	public InvalidOptionIdException() {
+		super(ResponseStatus.INVALID_OPTION_ID);
+	}
+}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/MyCarMasterException.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/exception/MyCarMasterException.java
@@ -1,9 +1,11 @@
 package softeer.be_my_car_master.global.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import softeer.be_my_car_master.global.response.ResponseStatus;
 
 @Getter
+@AllArgsConstructor
 public class MyCarMasterException extends RuntimeException {
 
 	private ResponseStatus responseStatus;

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/response/ResponseStatus.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/response/ResponseStatus.java
@@ -9,9 +9,9 @@ public enum ResponseStatus {
 
 	BAD_REQUEST(4000, "잘못된 요청입니다"),
 
-	INTERNAL_SERVER_ERROR(5000, "서버 내부에서 문제가 발생했습니다."),
+	INVALID_OPTION(4100, "선택 불가능한 옵션이 포함되어 있습니다."),
 
-	INVALID_OPTION_ID(4001, "선택 불가능한 옵션 ID입니다.");
+	INTERNAL_SERVER_ERROR(5000, "서버 내부에서 문제가 발생했습니다.");
 
 	private final int code;
 

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/response/ResponseStatus.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/global/response/ResponseStatus.java
@@ -9,7 +9,9 @@ public enum ResponseStatus {
 
 	BAD_REQUEST(4000, "잘못된 요청입니다"),
 
-	INTERNAL_SERVER_ERROR(5000, "서버 내부에서 문제가 발생했습니다.");
+	INTERNAL_SERVER_ERROR(5000, "서버 내부에서 문제가 발생했습니다."),
+
+	INVALID_OPTION_ID(4001, "선택 불가능한 옵션 ID입니다.");
 
 	private final int code;
 

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/adaptor/OptionJpaAdaptor.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/adaptor/OptionJpaAdaptor.java
@@ -47,6 +47,18 @@ public class OptionJpaAdaptor implements OptionPort {
 	}
 
 	@Override
+	public List<Long> findSelectableOptionIdsByTrimId(Long trimId) {
+		return trimAdditionalOptionJpaRepository.findUnselectableOptionIdsByTrimId(trimId);
+	}
+
+	@Override
+	public List<Option> findUnselectableOptions(Long trimId, List<Long> optionIds) {
+		return trimAdditionalOptionJpaRepository.findAllByIdIn(trimId, optionIds).stream()
+			.map(TrimAdditionalOptionEntity::toSimpleOption)
+			.collect(Collectors.toList());
+	}
+
+	@Override
 	public List<Long> findUnselectableOptionIdsByEngineId(Long engineId) {
 		return engineUnselectableOptionJpaRepository.findUnselectableOptionIdsByEngineId(engineId);
 	}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/entity/OptionEntity.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/entity/OptionEntity.java
@@ -3,7 +3,6 @@ package softeer.be_my_car_master.infrastructure.jpa.option.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/entity/TrimAdditionalOptionEntity.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/entity/TrimAdditionalOptionEntity.java
@@ -63,4 +63,12 @@ public class TrimAdditionalOptionEntity {
 			.tag(option.getTag())
 			.build();
 	}
+
+	public Option toSimpleOption() {
+		return Option.builder()
+			.id(option.getId())
+			.name(option.getName())
+			.price(price)
+			.build();
+	}
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/repository/TrimAdditionalOptionJpaRepository.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/option/repository/TrimAdditionalOptionJpaRepository.java
@@ -14,4 +14,15 @@ public interface TrimAdditionalOptionJpaRepository extends JpaRepository<TrimAdd
 		+ "JOIN FETCH tao.option o "
 		+ "WHERE tao.trim.id = :trimId")
 	List<TrimAdditionalOptionEntity> findAllByTrimId(Long trimId);
+
+	@Query("SELECT tao.option.id "
+		+ "FROM TrimAdditionalOptionEntity tao "
+		+ "WHERE tao.trim.id = :trimId")
+	List<Long> findUnselectableOptionIdsByTrimId(Long trimId);
+
+	@Query("SELECT tao "
+		+ "FROM TrimAdditionalOptionEntity tao "
+		+ "JOIN FETCH tao.option o "
+		+ "WHERE tao.trim.id = :trimId AND tao.option.id IN :optionIds")
+	List<TrimAdditionalOptionEntity> findAllByIdIn(Long trimId, List<Long> optionIds);
 }

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
@@ -1,5 +1,6 @@
 package softeer.be_my_car_master.api.engine.usecase;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
@@ -18,6 +19,7 @@ import softeer.be_my_car_master.api.engine.dto.response.GetUnselectableOptionsBy
 import softeer.be_my_car_master.api.engine.dto.response.UnselectableOptionDto;
 import softeer.be_my_car_master.api.option.usecase.port.OptionPort;
 import softeer.be_my_car_master.domain.option.Option;
+import softeer.be_my_car_master.global.exception.InvalidOptionIdException;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GetUnselectableOptionsByEngineUseCase Test")
@@ -33,7 +35,7 @@ class GetUnselectableOptionsByEngineUseCaseTest {
 	@DisplayName("엔진에 따라 선택 불가능한 옵션 목록을 조회합니다")
 	void execute() {
 		// given
-		Option option = Option.builder()
+		Option option1 = Option.builder()
 			.id(1L)
 			.name("임의의 옵션")
 			.category("SAFE")
@@ -47,7 +49,21 @@ class GetUnselectableOptionsByEngineUseCaseTest {
 			.tag(null)
 			.build();
 
-		given(optionPort.findSelectableOptionsByTrimId(any())).willReturn(Arrays.asList(option));
+		Option option2 = Option.builder()
+			.id(2L)
+			.name("임의의 옵션2")
+			.category("SAFE")
+			.summary("옵션 요약")
+			.description("옵션 상세설명")
+			.imgUrl("imgUrl")
+			.price(100000)
+			.ratio(22)
+			.isSuper(false)
+			.subOptions(null)
+			.tag(null)
+			.build();
+
+		given(optionPort.findSelectableOptionsByTrimId(any())).willReturn(Arrays.asList(option1, option2));
 		given(optionPort.findUnselectableOptionIdsByEngineId(any())).willReturn(Arrays.asList(1L, 3L));
 
 		// when
@@ -61,9 +77,38 @@ class GetUnselectableOptionsByEngineUseCaseTest {
 		SoftAssertions.assertSoftly(softAssertions -> {
 			softAssertions.assertThat(options).isNotNull();
 			softAssertions.assertThat(options).hasSize(1);
-			softAssertions.assertThat(optionExpected.getId()).isEqualTo(option.getId());
-			softAssertions.assertThat(optionExpected.getName()).isEqualTo(option.getName());
-			softAssertions.assertThat(optionExpected.getPrice()).isEqualTo(option.getPrice());
+			softAssertions.assertThat(optionExpected.getId()).isEqualTo(option1.getId());
+			softAssertions.assertThat(optionExpected.getName()).isEqualTo(option1.getName());
+			softAssertions.assertThat(optionExpected.getPrice()).isEqualTo(option1.getPrice());
 		});
+	}
+
+	@Test
+	@DisplayName("OptionIds가 트림에서 선택 불가능한 옵션을 포함한다면 InvalidOptionIdException이 발생합니다")
+	void invalidOptionIds() {
+		// given
+		Option option1 = Option.builder()
+			.id(1L)
+			.name("임의의 옵션")
+			.category("SAFE")
+			.summary("옵션 요약")
+			.description("옵션 상세설명")
+			.imgUrl("imgUrl")
+			.price(100000)
+			.ratio(22)
+			.isSuper(false)
+			.subOptions(null)
+			.tag(null)
+			.build();
+
+		given(optionPort.findSelectableOptionsByTrimId(any())).willReturn(Arrays.asList(option1));
+		given(optionPort.findUnselectableOptionIdsByEngineId(any())).willReturn(Arrays.asList(1L, 3L));
+
+		// when
+		// then
+		assertThrows(
+			InvalidOptionIdException.class,
+			() -> getUnselectableOptionsByEngineUseCase.execute(1L, 1L, Arrays.asList(1L, 2L))
+		);
 	}
 }

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/engine/usecase/GetUnselectableOptionsByEngineUseCaseTest.java
@@ -19,7 +19,7 @@ import softeer.be_my_car_master.api.engine.dto.response.GetUnselectableOptionsBy
 import softeer.be_my_car_master.api.engine.dto.response.UnselectableOptionDto;
 import softeer.be_my_car_master.api.option.usecase.port.OptionPort;
 import softeer.be_my_car_master.domain.option.Option;
-import softeer.be_my_car_master.global.exception.InvalidOptionIdException;
+import softeer.be_my_car_master.global.exception.InvalidOptionException;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GetUnselectableOptionsByEngineUseCase Test")
@@ -49,22 +49,9 @@ class GetUnselectableOptionsByEngineUseCaseTest {
 			.tag(null)
 			.build();
 
-		Option option2 = Option.builder()
-			.id(2L)
-			.name("임의의 옵션2")
-			.category("SAFE")
-			.summary("옵션 요약")
-			.description("옵션 상세설명")
-			.imgUrl("imgUrl")
-			.price(100000)
-			.ratio(22)
-			.isSuper(false)
-			.subOptions(null)
-			.tag(null)
-			.build();
-
-		given(optionPort.findSelectableOptionsByTrimId(any())).willReturn(Arrays.asList(option1, option2));
+		given(optionPort.findSelectableOptionIdsByTrimId(any())).willReturn(Arrays.asList(1L, 2L, 3L));
 		given(optionPort.findUnselectableOptionIdsByEngineId(any())).willReturn(Arrays.asList(1L, 3L));
+		given(optionPort.findUnselectableOptions(any(), any())).willReturn(Arrays.asList(option1));
 
 		// when
 		GetUnselectableOptionsByEngineResponse getUnselectableOptionsByEngineResponse =
@@ -84,30 +71,15 @@ class GetUnselectableOptionsByEngineUseCaseTest {
 	}
 
 	@Test
-	@DisplayName("OptionIds가 트림에서 선택 불가능한 옵션을 포함한다면 InvalidOptionIdException이 발생합니다")
+	@DisplayName("OptionIds가 트림에서 선택 불가능한 옵션을 포함한다면 InvalidOptionException이 발생합니다")
 	void invalidOptionIds() {
 		// given
-		Option option1 = Option.builder()
-			.id(1L)
-			.name("임의의 옵션")
-			.category("SAFE")
-			.summary("옵션 요약")
-			.description("옵션 상세설명")
-			.imgUrl("imgUrl")
-			.price(100000)
-			.ratio(22)
-			.isSuper(false)
-			.subOptions(null)
-			.tag(null)
-			.build();
-
-		given(optionPort.findSelectableOptionsByTrimId(any())).willReturn(Arrays.asList(option1));
-		given(optionPort.findUnselectableOptionIdsByEngineId(any())).willReturn(Arrays.asList(1L, 3L));
+		given(optionPort.findSelectableOptionIdsByTrimId(any())).willReturn(Arrays.asList(2L, 3L));
 
 		// when
 		// then
 		assertThrows(
-			InvalidOptionIdException.class,
+			InvalidOptionException.class,
 			() -> getUnselectableOptionsByEngineUseCase.execute(1L, 1L, Arrays.asList(1L, 2L))
 		);
 	}


### PR DESCRIPTION
## 개요
- #151 

## 작업사항
- 선택된 옵션 중 엔진에서 선택불가능한 옵션 조회 구현
- 해당 트림에서 선택 불가능한 옵션이 optionIds에 존재하는 경우 예외처리

## 고민사항
- Exception 이런식으로 처리하면 되는건가..?
- ResponseStatus의 코드 그냥 아무거나 넣었는데 뭐 넣어야할지 논의해봐야할 것 같습니다-!
