### PR TITLE
[Feature] 하단 확장에 사용되는 재사용 컴포넌트 생성

### DIFF
--- a/FE-MyCarMaster/src/App.tsx
+++ b/FE-MyCarMaster/src/App.tsx
@@ -73,7 +73,7 @@ const Filler = styled.div`
   top: 64%;
   width: 100%;
   height: 36%;
-  background-color: #f2f2f2;
+  background-color: ${({ theme }) => theme.colors.GREY1};
   z-index: -1;
 `;
 

--- a/FE-MyCarMaster/src/components/Footer/FoldScreen.tsx
+++ b/FE-MyCarMaster/src/components/Footer/FoldScreen.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import styled from "styled-components";
+import AngleUp from "../../assets/icons/AngleUp.svg";
+import AngleDown from "../../assets/icons/AngleDown.svg";
+import ScreenContainer from "./screen_view/ScreenContainer";
+
+type FoldScreenProps = {
+  text: string;
+  $switch: "searchTrim" | "option";
+};
+
+export default function FoldScreen({ text, $switch }: FoldScreenProps) {
+  const [isFold, setIsFold] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const showFold = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const target = e.currentTarget;
+    if (isFold) {
+      target.style.animation = "moveDown 0.5s ease-in-out forwards";
+    } else {
+      target.style.animation = "moveUp 0.5s ease-in-out forwards";
+    }
+    setLoading(true);
+
+    setTimeout(() => {
+      setIsFold(!isFold);
+      setLoading(false);
+    }, 500);
+  };
+
+  return (
+    <Conatiner>
+      <ButtonContainer onClick={showFold} $style={isFold}>
+        {isFold ? <AngleDownIcon /> : <AngleUpIcon />}
+
+        <Text $show={loading}>
+          {!isFold
+            ? text
+            : $switch === "searchTrim"
+            ? "원하는 기능을 선택하시면 해당 기능이 포함된 트림을 추천해드려요!"
+            : "추가 옵션 선택하기"}
+        </Text>
+
+        {!isFold && <Bar $show={loading} />}
+        <ScreenContainer
+          $loading={loading}
+          $show={isFold}
+          onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
+            e.stopPropagation()
+          }
+        />
+      </ButtonContainer>
+    </Conatiner>
+  );
+}
+
+const Conatiner = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: absolute;
+  width: 100%;
+  bottom: 0%;
+  align-items: center;
+  z-index: 1;
+`;
+
+const AngleUpIcon = styled.img.attrs({
+  src: AngleUp,
+})``;
+
+const AngleDownIcon = styled.img.attrs({
+  src: AngleDown,
+})`
+  margin: 0.5rem;
+`;
+
+const Bar = styled.div<{ $show: boolean }>`
+  width: 6rem;
+  height: 0.0625rem;
+  background-color: ${({ theme }) => theme.colors.ACTIVE_BLUE};
+  animation: ${({ $show }) =>
+    $show ? "disappear 0.5s ease-in-out" : "appear 0.5s ease-in-out"};
+
+  @keyframes disappear {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
+  @keyframes appear {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+`;
+
+const Text = styled.p<{ $show: boolean }>`
+  ${({ theme }) => theme.fonts.ContentMedium1};
+  animation: ${({ $show }) =>
+    $show ? "disappear 0.5s ease-in-out" : "appear 0.5s ease-in-out"};
+
+  @keyframes disappear {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
+  @keyframes appear {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+`;
+
+const ButtonContainer = styled.div<{ $style: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  width: ${({ $style }) => ($style ? "100vw" : "auto")};
+  height: ${({ $style }) => ($style ? "70vh" : "auto")};
+
+  background-color: ${({ theme }) => theme.colors.GREY1};
+  box-shadow: ${({ $style }) =>
+    $style ? "0px -6px 4px -4px rgba(0, 0, 0, 0.21);" : "0px 0px 0px 0px"};
+
+  &:hover {
+    ${AngleUpIcon} {
+      animation: slowlyMove ease-in-out forwards infinite 1s;
+
+      @keyframes slowlyMove {
+        0% {
+          transform: translateY(0%);
+        }
+        50% {
+          transform: translateY(-25%);
+        }
+        100% {
+          transform: translateY(0%);
+        }
+      }
+    }
+    ${AngleDownIcon} {
+      animation: slowlyMove ease-in-out forwards infinite 1s;
+
+      @keyframes slowlyMove {
+        0% {
+          transform: translateY(0%);
+        }
+        50% {
+          transform: translateY(25%);
+        }
+        100% {
+          transform: translateY(0%);
+        }
+      }
+    }
+
+    // Bar, Text Color Change
+    ${Bar} {
+      background-color: ${({ theme }) => theme.colors.NAVYBLUE5};
+    }
+    ${Text} {
+      color: ${({ theme }) => theme.colors.NAVYBLUE5};
+    }
+  }
+
+  @keyframes moveUp {
+    from {
+      transform: translateY(calc(100% - 2.5rem));
+      width: 100vw;
+      height: 70vh;
+    }
+    to {
+      transform: translateY(0%);
+      width: 100vw;
+      height: 70vh;
+    }
+  }
+
+  @keyframes moveDown {
+    from {
+      transform: translateY(0%);
+      width: 100vw;
+    }
+    to {
+      transform: translateY(calc(100% - 2.5rem));
+    }
+  }
+`;

--- a/FE-MyCarMaster/src/components/Footer/Footer.tsx
+++ b/FE-MyCarMaster/src/components/Footer/Footer.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import SelectListWrapper from "./SelectListWrapper";
 import Button from "../common/Button/Button";
 import theme from "../../styles/Theme";
+import FoldScreen from "./FoldScreen";
 import {
   useQuotationState,
   useQuotationDispatch,
@@ -25,7 +26,7 @@ function Footer() {
         },
       },
     });
-  }
+  };
 
   return (
     <Container>
@@ -65,6 +66,7 @@ function Footer() {
           </ButtonContainer>
         </HeightFittingContainer>
       </RightContainer>
+      <FoldScreen text={"내게 맞는 트림 찾기"} $switch={"searchTrim"} />
     </Container>
   );
 }
@@ -74,6 +76,7 @@ const Container = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  position: relative;
   width: 100%;
   height: 16rem;
 `;

--- a/FE-MyCarMaster/src/components/Footer/screen_view/ScreenContainer.tsx
+++ b/FE-MyCarMaster/src/components/Footer/screen_view/ScreenContainer.tsx
@@ -1,0 +1,123 @@
+import styled from "styled-components";
+import SearchTrimBox from "../../common/SearchTrimBox/SearchTrimBox";
+import OptionCheckBox from "../../common/CheckBox/OptionCheckBox";
+import Button from "../../common/Button/Button";
+type ScreenContainerProps = {
+  $loading: boolean;
+  $show: boolean;
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+};
+export default function ScreenContainer({
+  $loading,
+  $show,
+  onClick,
+}: ScreenContainerProps) {
+  return (
+    <Container $loading={$loading} $show={$show} onClick={onClick}>
+      <TrimSelectContainer>
+        <SearchTrimBox
+          name={"Exclusive"}
+          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
+          price={2000}
+          status={"default"}
+          isOption={"default"}
+        />
+        <SearchTrimBox
+          name={"Le Blanc"}
+          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
+          price={38960000}
+          status={"choice"}
+          isOption={"none"}
+        />
+        <SearchTrimBox
+          name={"Prestige"}
+          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
+          price={38960000}
+          status={"none"}
+          isOption={"none"}
+        />
+
+        <SearchTrimBox
+          name={"Caligraphy"}
+          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
+          price={2000}
+          status={"default"}
+          isOption={"add"}
+        />
+      </TrimSelectContainer>
+      <CheckOptionContainer>
+        <OptionCheckBox />
+        <OptionCheckBox />
+        <OptionCheckBox />
+        <OptionCheckBox />
+        <OptionCheckBox />
+        <OptionCheckBox />
+        <OptionCheckBox />
+        <OptionCheckBox />
+        <OptionCheckBox />
+      </CheckOptionContainer>
+      <ButtonContainer>
+        <Button $x={9.5625} $y={2.25} text={"나가기"} />
+        <Button $x={9.5625} $y={2.25} text={"확인"} />
+      </ButtonContainer>
+    </Container>
+  );
+}
+
+const Container = styled.div<ScreenContainerProps>`
+  display: ${({ $show }) => ($show ? "flex" : "none")};
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: 16rem;
+
+  animation: ${({ $show }) =>
+    $show ? "appear 0.5s ease-in-out forwards" : ""};
+  animation: ${({ $loading }) =>
+    $loading ? "disappear 0.5s ease-in-out forwards" : ""};
+
+  @keyframes appear {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes disappear {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+`;
+
+const TrimSelectContainer = styled.div`
+  margin: 1.6rem 0 0.75rem 0;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+`;
+
+const CheckOptionContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  gap: 0.5rem;
+  margin: 1.5rem;
+`;

--- a/FE-MyCarMaster/src/components/common/CheckBox/OptionCheckBox.tsx
+++ b/FE-MyCarMaster/src/components/common/CheckBox/OptionCheckBox.tsx
@@ -1,0 +1,14 @@
+import { Container, CheckBox, Check, Name, Detail } from "./style";
+
+export default function OptionCheckBox() {
+  return (
+    <Container>
+      <CheckBox>
+        <Check type="checkbox" />
+        <span></span>
+      </CheckBox>
+      <Name>기본 제공</Name>
+      <Detail>기본 제공</Detail>
+    </Container>
+  );
+}

--- a/FE-MyCarMaster/src/components/common/CheckBox/style.ts
+++ b/FE-MyCarMaster/src/components/common/CheckBox/style.ts
@@ -1,0 +1,42 @@
+import styled, { css, RuleSet } from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  width: 20.875rem;
+
+  border: 1px solid ${(props) => props.theme.colors.GREY2};
+  background-color: ${(props) => props.theme.colors.WHITE};
+`;
+
+export const CheckBox = styled.div`
+  width: 2rem;
+  height: 2rem;
+  border: 2px solid ${(props) => props.theme.colors.GREY1};
+  cursor: pointer;
+`;
+
+export const Check = styled.input`
+  display: none;
+  &:checked + ${CheckBox} {
+    background-color: ${(props) => props.theme.colors.GOLD4};
+  }
+`;
+
+export const Name = styled.p`
+  ${(props) => props.theme.fonts.contentMedium};
+  margin-left: 1rem;
+`;
+
+export const Detail = styled.p`
+  ${(props) => props.theme.fonts.contentMedium};
+  color: ${(props) => props.theme.colors.NAVYBLUE5};
+  margin-right: 1rem;
+`;
+
+type CSSProps = {
+  $background?: RuleSet;
+  $text?: RuleSet;
+};

--- a/FE-MyCarMaster/src/components/common/SearchTrimBox/SearchTrimBox.tsx
+++ b/FE-MyCarMaster/src/components/common/SearchTrimBox/SearchTrimBox.tsx
@@ -9,12 +9,16 @@ import {
   NoneCSS,
 } from "./style";
 import TagItem from "../TagItem/TagItem";
+
+type StatusType = "default" | "choice" | "none";
+type OptionType = "default" | "add" | "none";
+
 type SearchTrimBoxProps = {
   name: string;
   description: string;
   price: number;
-  status: string;
-  isOption?: "default" | "add" | "none";
+  status: StatusType;
+  isOption?: OptionType;
 };
 
 export default function SearchTrimBox({
@@ -28,12 +32,14 @@ export default function SearchTrimBox({
   const nameStyle = calculateName(status);
   const descriptionStyle = calculateDescription(status);
   const priceStyle = calculatePrice(status);
+
+  console.log(nameStyle);
   return (
     <Container $background={backgroundStyle}>
       <Name $text={nameStyle}>{name}</Name>
       <Description $text={descriptionStyle}>{description}</Description>
       <BottomContainer>
-        <Price $text={priceStyle}>{price}</Price>
+        <Price $text={priceStyle}>{price.toLocaleString("ko-KR")} 원</Price>
         {isOption === "default" ? (
           <TagItem text={"기본 제공"} $switch="DefaultsearchTrim" />
         ) : (
@@ -46,7 +52,7 @@ export default function SearchTrimBox({
   );
 }
 
-const calculateBackground = (status: string) => {
+const calculateBackground = (status: StatusType) => {
   switch (status) {
     case "none":
       return NoneCSS.Background;
@@ -57,7 +63,7 @@ const calculateBackground = (status: string) => {
   }
 };
 
-const calculateName = (status: string) => {
+const calculateName = (status: StatusType) => {
   switch (status) {
     case "none":
       return NoneCSS.Name;
@@ -68,7 +74,7 @@ const calculateName = (status: string) => {
   }
 };
 
-const calculateDescription = (status: string) => {
+const calculateDescription = (status: StatusType) => {
   switch (status) {
     case "none":
       return NoneCSS.Description;
@@ -79,7 +85,7 @@ const calculateDescription = (status: string) => {
   }
 };
 
-const calculatePrice = (status: string) => {
+const calculatePrice = (status: StatusType) => {
   switch (status) {
     case "none":
       return NoneCSS.Price;

--- a/FE-MyCarMaster/src/components/common/SearchTrimBox/style.ts
+++ b/FE-MyCarMaster/src/components/common/SearchTrimBox/style.ts
@@ -3,11 +3,14 @@ import styled, { css, RuleSet } from "styled-components";
 export const Container = styled.div<CSSProps>`
   width: 12.5rem;
   height: 10.25rem;
-  padding: 0.75rem 1.5rem;
+  padding: 1rem;
 
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: space-around;
+
+  ${(props) => props.$background}
+  border: 1px solid ${(props) => props.theme.colors.GREY2};
 `;
 
 export const Name = styled.p<CSSProps>`

--- a/FE-MyCarMaster/src/components/common/TagItem/style.ts
+++ b/FE-MyCarMaster/src/components/common/TagItem/style.ts
@@ -7,6 +7,8 @@ export const Text = styled.p<CSSProps>`
 export const TextContainer = styled.div<CSSProps>`
   ${(props) => props.$padding}
   ${(props) => props.$background}
+  display: flex;
+  align-items: center;
 `;
 
 type CSSProps = {

--- a/FE-MyCarMaster/src/styles/Theme.ts
+++ b/FE-MyCarMaster/src/styles/Theme.ts
@@ -15,6 +15,7 @@ const colors = {
   NAVYBLUE3: "#C6D2F0",
   NAVYBLUE4: "#96A9DC",
   NAVYBLUE5: "#1A3276",
+  ACTIVE_BLUE: "#007FA8",
 };
 
 const fontSize = {


### PR DESCRIPTION
## 개요
- #189

## 작업사항
- 하단 FoldScreen 및 ScreenContainer 레이아웃 구성
- 내게 맞는 트림 찾기 레이아웃 구성 및 컴포넌트 배치

## 고민사항
- 애니메이션 너무 힘들다. 하지만 깨달았다.
- 추가로, 트림 및 옵션 페이지에서만 하단 FoldScreen을 띄어줘야 함.
- 또, ScreenContainer에서 분기될 내게 맞는 트림찾기와 기본옵션보기 뷰를 나눠야 함.
- 마지막으로, 재사용 컴포넌트 CheckBox를 마무리해야 함.
