### PR TITLE
[Feature] 하단 확장에 사용되는 재사용 컴포넌트 생성

### DIFF
--- a/FE-MyCarMaster/src/components/Footer/view/TrimSelect.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/TrimSelect.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
 import styled from "styled-components";
 import { useTrimState, useTrimDispatch } from "../../../contexts/TrimContext";
 import { useQuotationDispatch } from "../../../contexts/QuotationContext";
 import OptionBox from "../../common/OptionBox/OptionBox";
+import OptionList from "../../common/OptionList/OptionList";
 
 export default function TrimSelect() {
   const { trimList, trimId } = useTrimState();
+  const [showDetail, setShowDetail] = useState(false);
   const trimDispatch = useTrimDispatch();
   const quotationDispatch = useQuotationDispatch();
 
@@ -38,9 +41,23 @@ export default function TrimSelect() {
               $switch="trim"
               $choice={trimId === trim.id}
               handleClick={() => selectTrim(trim.id)}
+              handleClickDetail={() => setShowDetail(!showDetail)}
             />
           );
         })}
+      <Exam>
+        {showDetail && (
+          <>
+            <OptionList $name="파워트레인/성능" />
+            <OptionList $name="지능형 안전 기술" />
+            <OptionList $name="안전" />
+            <OptionList $name="외관" />
+            <OptionList $name="내장" />
+            <OptionList $name="시트" />
+            <OptionList $name="편의" />
+          </>
+        )}
+      </Exam>
     </Container>
   );
 }
@@ -50,4 +67,13 @@ const Container = styled.div`
   flex-direction: row;
   width: 59.5rem;
   gap: 0.5rem;
+`;
+
+const Exam = styled.div`
+  width: 100%;
+  align-self: center;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 `;

--- a/FE-MyCarMaster/src/components/common/OptionBox/OptionBox.tsx
+++ b/FE-MyCarMaster/src/components/common/OptionBox/OptionBox.tsx
@@ -21,6 +21,7 @@ type OptionBoxProp = {
   $considered?: boolean;
   $none?: boolean; // 추후, 선택할 수 없는 옵션에 대한 처리를 위해 추가
   handleClick?: () => void;
+  handleClickDetail?: () => void;
 };
 
 function OptionBox({
@@ -33,6 +34,7 @@ function OptionBox({
   $switch,
   $considered,
   handleClick,
+  handleClickDetail,
 }: OptionBoxProp) {
   return (
     <Container
@@ -87,7 +89,10 @@ function OptionBox({
                 <Price $style={$choice ? ActiveCSS.Price : DefaultCSS.Price}>
                   {$price?.toLocaleString("ko-KR")} 원
                 </Price>
-                <Detail $style={$choice ? ActiveCSS.Detail : DefaultCSS.Detail}>
+                <Detail
+                  $style={$choice ? ActiveCSS.Detail : DefaultCSS.Detail}
+                  onClick={handleClickDetail}
+                >
                   자세히보기 &gt;
                 </Detail>
               </>

--- a/FE-MyCarMaster/src/components/common/OptionList/OptionList.tsx
+++ b/FE-MyCarMaster/src/components/common/OptionList/OptionList.tsx
@@ -1,0 +1,54 @@
+import {
+  Container,
+  ListContainer,
+  Text,
+  Icon,
+  OptionItem,
+  Line,
+} from "./style";
+import { useState, useRef, useEffect } from "react";
+
+// 임시 데이터
+const data = [
+  { id: 1, name: "엔진오일" },
+  { id: 2, name: "브레이크오일" },
+  { id: 3, name: "에어컨필터" },
+];
+
+type OptionListProps = {
+  $name: string;
+};
+
+export default function OptionList({ $name }: OptionListProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // initalil isFirst
+  const isFirst = useRef(true);
+
+  useEffect(() => {
+    if (isFirst.current) {
+      isFirst.current = false;
+      return;
+    }
+  }, [isOpen]);
+
+  console.log(isFirst.current);
+  return (
+    <Container $isOpen={isOpen}>
+      <ListContainer $isOpen={isOpen}>
+        <Text>{$name}</Text>
+        <Icon $isOpen={true} onClick={() => setIsOpen(!isOpen)} />
+      </ListContainer>
+      <Line $isOpen={isOpen} $isFirst={isFirst.current} />
+      {isOpen && (
+        <ul>
+          {data.map((item) => (
+            <OptionItem $isOpen={isOpen} key={item.id}>
+              {item.name}
+            </OptionItem>
+          ))}
+        </ul>
+      )}
+    </Container>
+  );
+}

--- a/FE-MyCarMaster/src/components/common/OptionList/style.ts
+++ b/FE-MyCarMaster/src/components/common/OptionList/style.ts
@@ -1,0 +1,105 @@
+import styled, { css, keyframes } from "styled-components";
+import AngleUp from "../../../assets/icons/AngleUp.svg";
+import AngleDown from "../../../assets/icons/AngleDown.svg";
+
+const expandAnimation = keyframes`
+  from {
+    height: calc(2rem + 1.5rem + 0.75rem + 0.75rem);
+  }
+  to {
+    height: 100%;
+  }
+`;
+
+const ListTextAppearAnimation = keyframes`
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+`;
+
+const LineAppearAnimation = keyframes`
+    from {
+    }
+    to {
+        width: 100%;
+    }
+`;
+
+const LineDisappearAnimation = keyframes`
+    from {
+        width: 100%;
+    }
+    to {
+        width: 0%;
+    }
+`;
+
+export const Container = styled.div<{ $isOpen: boolean }>`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 1.5rem;
+  width: 80%;
+  border: 1px solid ${(props) => props.theme.colors.GREY2};
+  background-color: ${(props) => props.theme.colors.WHITE};
+
+  ${(props) =>
+    props.$isOpen &&
+    css`
+      animation: ${expandAnimation} 1s ease-in-out forwards;
+    `}
+
+  & + & {
+    margin: 0.875rem 0;
+  }
+`;
+export const ListContainer = styled.div<{ $isOpen: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const Text = styled.div`
+  font-size: 1.25rem;
+`;
+
+export const Icon = styled.div<{ $isOpen: boolean }>`
+  width: 2rem;
+  height: 2rem;
+  background-image: url(${(props) => (props.$isOpen ? AngleUp : AngleDown)});
+  background-repeat: no-repeat;
+  background-position: center;
+`;
+
+export const OptionItem = styled.div<{ $isOpen: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+
+  ${(props) =>
+    props.$isOpen &&
+    css`
+      animation: ${ListTextAppearAnimation} 1s ease-in-out forwards;
+    `}
+`;
+
+export const Line = styled.div<{ $isOpen: boolean; $isFirst: boolean }>`
+  width: 0%;
+  height: 1px;
+  background-color: ${(props) => props.theme.colors.GREY2};
+  align-self: center;
+
+  ${(props) =>
+    props.$isFirst
+      ? ""
+      : props.$isOpen
+      ? css`
+          animation: ${LineAppearAnimation} 1s ease-in-out forwards;
+        `
+      : css`
+          animation: ${LineDisappearAnimation} 1s ease-in-out forwards;
+        `}
+`;


### PR DESCRIPTION
## 개요
- #189 

## 작업사항
- OptionList 컴포넌트 디자인
- TrimSelect에서 생성되는 OptionList 적용 확인

## 확인사항
- OptionList는 name을 기본 프로퍼티로 가지며, 안에 있는 data는 현재 dummy data를 사용하고 있음.
- TrimSelect에서 사용되는 OptionList는 임시 <Exam> 태그에 둘러쌓여 있으며(Modal 개발완료시 Exam이 Modal이 될 듯), 상태관리를 통해 OptionList를 생성해야 함.

```jsx
// TrimSelect.tsx
...
<Exam>
        {showDetail && ( // showDetail은 useState 상태
          <>
            <OptionList $name="파워트레인/성능" />
            <OptionList $name="지능형 안전 기술" />
            <OptionList $name="안전" />
            <OptionList $name="외관" />
            <OptionList $name="내장" />
            <OptionList $name="시트" />
            <OptionList $name="편의" />
          </>
        )}
</Exam>
```
