### PR TITLE
[Feature] 하단 확장 레이아웃 및 컴포넌트 구성

### DIFF
--- a/FE-MyCarMaster/src/components/Footer/FoldScreen.tsx
+++ b/FE-MyCarMaster/src/components/Footer/FoldScreen.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import AngleUp from "../../assets/icons/AngleUp.svg";
 import AngleDown from "../../assets/icons/AngleDown.svg";
 import MyTrimSearchScreen from "./screen_view/MyTrimSearchScreen";
-
+import DefaultOptionScreen from "./screen_view/DefaultOptionScreen";
 import { QuotationType } from "../../types/quotation.types";
 import { useTrimState, useTrimDispatch } from "../../contexts/TrimContext";
 import { useQuotationDispatch } from "../../contexts/QuotationContext";
@@ -36,17 +36,20 @@ export default function FoldScreen({ text, $switch }: FoldScreenProps) {
   };
 
   const searchHandler = (optionList: QuotationType[], selected: number) => {
+    const target = document.querySelector(".fold-screen") as HTMLDivElement;
+    target.style.animation = "moveDown 0.5s ease-in-out forwards";
+
+    setLoading(true);
+
+    setTimeout(() => {
+      setIsFold(false);
+      setLoading(false);
+    }, 500);
+
     trimDispatch({
       type: "SELECT_TRIM",
       payload: {
         trimId: selected,
-      },
-    });
-
-    quotationDispatch({
-      type: "SET_MY_TRIM_OPTIONS",
-      payload: {
-        optionList: optionList,
       },
     });
 
@@ -60,15 +63,12 @@ export default function FoldScreen({ text, $switch }: FoldScreenProps) {
       },
     });
 
-    const target = document.querySelector(".fold-screen") as HTMLDivElement;
-    target.style.animation = "moveDown 0.5s ease-in-out forwards";
-
-    setLoading(true);
-
-    setTimeout(() => {
-      setIsFold(false);
-      setLoading(false);
-    }, 500);
+    quotationDispatch({
+      type: "SET_MY_TRIM_OPTIONS",
+      payload: {
+        optionList: optionList,
+      },
+    });
   };
 
   return (
@@ -85,19 +85,28 @@ export default function FoldScreen({ text, $switch }: FoldScreenProps) {
             ? text
             : $switch === "searchTrim"
             ? "원하는 기능을 선택하시면 해당 기능이 포함된 트림을 추천해드려요!"
-            : "추가 옵션 선택하기"}
+            : "추가 옵션 선택하러 가기"}
         </Text>
 
         {!isFold && $switch === "searchTrim" && <Bar $show={loading} />}
-        <MyTrimSearchScreen
-          $loading={loading}
-          $show={isFold}
-          onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
-            e.stopPropagation()
-          }
-          //onSearch: (idData: IDDataProps[], selected: number) => void;
-          onSearch={searchHandler}
-        />
+        {$switch === "searchTrim" ? (
+          <MyTrimSearchScreen
+            $loading={loading}
+            $show={isFold}
+            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
+              e.stopPropagation()
+            }
+            onSearch={searchHandler}
+          />
+        ) : (
+          <DefaultOptionScreen
+            $loading={loading}
+            $show={isFold}
+            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
+              e.stopPropagation()
+            }
+          />
+        )}
       </ButtonContainer>
     </Conatiner>
   );

--- a/FE-MyCarMaster/src/components/Footer/Footer.tsx
+++ b/FE-MyCarMaster/src/components/Footer/Footer.tsx
@@ -85,7 +85,7 @@ function Footer() {
         <FoldScreen text={"내게 맞는 트림 찾기"} $switch={"searchTrim"} />
       )}
       {navigationId === 6 && (
-        <FoldScreen text={"추가 옵션 선택하기"} $switch={"option"} />
+        <FoldScreen text={"기본 옵션 보기"} $switch={"option"} />
       )}
     </Container>
   );

--- a/FE-MyCarMaster/src/components/Footer/screen_view/DefaultOptionScreen.tsx
+++ b/FE-MyCarMaster/src/components/Footer/screen_view/DefaultOptionScreen.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import styled from "styled-components";
+import CategoryList from "../../common/CategoryList/CategoryList";
+import GridOptionList from "../../common/OptionList/GridOptionList";
+
+const data = [
+  {
+    id: 1,
+    category: "파워트레인/성능",
+    name: "디젤 2.2 엔진",
+    imgUrl:
+      "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/second-row-ventilation-seat.png",
+    description:
+      "강력한 토크와 탁월한 효율로 여유있는 파워와 높은 연비를 제공하는 디젤엔진입니다.\n최고출력 : 202마력\n최대토크 : 45.0kgf·m",
+  },
+  {
+    id: 3,
+    category: "파워트레인/성능",
+    name: "8단 자동변속기",
+    imgUrl:
+      "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/second-row-ventilation-seat.png",
+    description:
+      "전달 효율 증대로 전 엔진 동급 최고의 연비를 구현함은 물론, 최적의 변속 성능으로 드라이빙 감성까지 향상시켜줍니다.",
+  },
+  {
+    id: 4,
+    category: "파워트레인/성능",
+    name: "ISG 시스템",
+    imgUrl:
+      "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/second-row-ventilation-seat.png",
+    description:
+      "신호 대기 상황이거나 정차 중일 때 차의 엔진을 일시 정지하여 연비를 향상시키고, 배출가스 발생을 억제하는 시스템입니다.",
+  },
+  {
+    id: 5,
+    category: "파워트레인/성능",
+    name: "ISG 시스템",
+    imgUrl:
+      "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/second-row-ventilation-seat.png",
+    description:
+      "신호 대기 상황이거나 정차 중일 때 차의 엔진을 일시 정지하여 연비를 향상시키고, 배출가스 발생을 억제하는 시스템입니다.",
+  },
+  {
+    id: 6,
+    category: "파워트레인/성능",
+    name: "ISG 시스템",
+    imgUrl:
+      "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/second-row-ventilation-seat.png",
+    description:
+      "신호 대기 상황이거나 정차 중일 때 차의 엔진을 일시 정지하여 연비를 향상시키고, 배출가스 발생을 억제하는 시스템입니다.",
+  },
+  {
+    id: 7,
+    category: "파워트레인/성능",
+    name: "ISG 시스템",
+    imgUrl:
+      "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/second-row-ventilation-seat.png",
+    description:
+      "신호 대기 상황이거나 정차 중일 때 차의 엔진을 일시 정지하여 연비를 향상시키고, 배출가스 발생을 억제하는 시스템입니다.",
+  },
+];
+
+type DefaultOptionScreenProps = {
+  $loading: boolean;
+  $show: boolean;
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+};
+
+type CategoryType =
+  | "파워트레인/성능"
+  | "지능형 안전기술"
+  | "안전"
+  | "외관"
+  | "내장"
+  | "시트"
+  | "편의";
+
+type ListType = {
+  id: number;
+  name: string;
+  imgUrl: string;
+  description: string;
+};
+
+export default function DefaultOptionScreen({
+  $loading,
+  $show,
+  onClick,
+}: DefaultOptionScreenProps) {
+  const [selected, setSelected] = useState<CategoryType>("파워트레인/성능");
+
+  const onClickHandler = (category: CategoryType) => {
+    setSelected(category as CategoryType);
+  };
+
+  const handleClick = (item: ListType) => {
+    console.log(item);
+    // 여기에 모달 띄어주면 됩니다.
+  };
+
+  const filterData = data.filter((item) => item.category === selected);
+
+  return (
+    <Container $loading={$loading} $show={$show} onClick={onClick}>
+      <CategoryListContainer>
+        <CategoryList
+          categories={[
+            "파워트레인/성능",
+            "지능형 안전기술",
+            "안전",
+            "외관",
+            "내장",
+            "시트",
+            "편의",
+          ]}
+          indexSetter={selected}
+          onClickHandler={(_index, category) =>
+            onClickHandler(category as CategoryType)
+          }
+          $switch={"default"}
+        />
+      </CategoryListContainer>
+      <GridOptionListContainer>
+        <GridOptionList list={filterData} handleClick={handleClick} />
+      </GridOptionListContainer>
+    </Container>
+  );
+}
+
+const Container = styled.div<DefaultOptionScreenProps>`
+  display: ${({ $show }) => ($show ? "flex" : "none")};
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  gap: 1.5rem;
+
+  animation: ${({ $show }) =>
+    $show ? "appear 0.5s ease-in-out forwards" : ""};
+  animation: ${({ $loading }) =>
+    $loading ? "disappear 0.5s ease-in-out forwards" : ""};
+
+  @keyframes appear {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes disappear {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+`;
+
+const CategoryListContainer = styled.div`
+  margin-top: 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  width: 80%;
+`;
+
+const GridOptionListContainer = styled.div`
+  margin-top: 1.5rem;
+  width: 80%;
+  height: 75%;
+`;

--- a/FE-MyCarMaster/src/components/Footer/screen_view/MyTrimSearchScreen.tsx
+++ b/FE-MyCarMaster/src/components/Footer/screen_view/MyTrimSearchScreen.tsx
@@ -4,6 +4,8 @@ import OptionCheckBox from "../../common/CheckBox/OptionCheckBox";
 import Button from "../../common/Button/Button";
 import { useState } from "react";
 import theme from "../../../styles/Theme";
+import { useTrimState } from "../../../contexts/TrimContext";
+import { QuotationType } from "../../../types/quotation.types";
 
 //dummy data
 const data = [
@@ -19,13 +21,16 @@ const data = [
     subOptions: null,
     filter: {
       unavailableTrimIds: [],
-      additionalTrimIds: [1, 2],
+      additionalTrimIds: [2, 1],
       defaultTrimIds: [3, 4],
     },
     appliedOption: {
       id: 100,
+      category: "CONVENIENCE",
       name: "2열 통풍시트",
       price: 400000,
+      imgUrl:
+        "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/second-row-ventilation-seat.png",
     },
   },
   {
@@ -39,13 +44,15 @@ const data = [
     subOptions: null,
     filter: {
       unavailableTrimIds: [],
-      additionalTrimIds: [2],
-      defaultTrimIds: [1, 3, 4],
+      additionalTrimIds: [1],
+      defaultTrimIds: [2, 3, 4],
     },
     appliedOption: {
       id: 125,
+      category: "SAFE",
       name: "주차보조 시스템 1",
       price: 1090000,
+      imgUrl: "https://h5-test-bucket.s3.ap-northeast-2.amazonaws.com/1.png",
     },
   },
   {
@@ -58,14 +65,16 @@ const data = [
       "컬러 LCD 클러스터(1,920x720)는 시인성이 높고 정보 파악이 용이하며, 주행모드별 차별화된 그래픽으로 즐거운 드라이빙 환경을 제공합니다.",
     subOptions: null,
     filter: {
-      unavailableTrimIds: [2],
+      unavailableTrimIds: [1],
       additionalTrimIds: [],
-      defaultTrimIds: [1, 3, 4],
+      defaultTrimIds: [2, 3, 4],
     },
     appliedOption: {
       id: 49,
+      category: "INTERNAL",
       name: "계기판 클러스터(12.3인치 컬러 LCD)",
       price: 0,
+      imgUrl: "https://h5-test-bucket.s3.ap-northeast-2.amazonaws.com/1.png",
     },
   },
   {
@@ -79,14 +88,16 @@ const data = [
       "스마트 크루즈 작동 중 고속도로/도시고속도로/자동차전용 도로 내 고속도로 진출입로 주행 시 차로를 판단하여 사전감속 또는 최적 속도에 맞추어 감속을 진행합니다.",
     subOptions: null,
     filter: {
-      unavailableTrimIds: [2],
-      additionalTrimIds: [1, 3],
+      unavailableTrimIds: [1],
+      additionalTrimIds: [2, 3],
       defaultTrimIds: [4],
     },
     appliedOption: {
       id: 93,
+      category: "SAFE",
       name: "현대스마트센스 1",
       price: 790000,
+      imgUrl: "https://h5-test-bucket.s3.ap-northeast-2.amazonaws.com/1.png",
     },
   },
   {
@@ -99,14 +110,16 @@ const data = [
       "주요 주행 정보를 전면 윈드실드에 표시하며, 밝기가 최적화되어 주간에도 시인성이 뛰어납니다.",
     subOptions: null,
     filter: {
-      unavailableTrimIds: [2],
-      additionalTrimIds: [1, 3],
+      unavailableTrimIds: [1],
+      additionalTrimIds: [2, 3],
       defaultTrimIds: [4],
     },
     appliedOption: {
       id: 92,
+      category: "SAFE",
       name: "컴포트 2",
       price: 1090000,
+      imgUrl: "https://h5-test-bucket.s3.ap-northeast-2.amazonaws.com/1.png",
     },
   },
   {
@@ -126,8 +139,11 @@ const data = [
     },
     appliedOption: {
       id: 129,
+      category: "CONVENIENCE",
       name: "전후석 통합 터치 공조 컨트롤",
       price: 0,
+      imgUrl:
+        "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/front-and-rear-integrated-touch-control.png",
     },
   },
   {
@@ -147,8 +163,10 @@ const data = [
     },
     appliedOption: {
       id: 132,
+      category: "MULTIMEDIA",
       name: "KRELL 사운드 패키지",
       price: 690000,
+      imgUrl: "https://h5-test-bucket.s3.ap-northeast-2.amazonaws.com/1.png",
     },
   },
   {
@@ -167,8 +185,11 @@ const data = [
     },
     appliedOption: {
       id: 133,
+      category: "EXTERNAL",
       name: "캘리그래피 전용 디자인",
       price: 0,
+      imgUrl:
+        "https://h5-image.s3.ap-northeast-2.amazonaws.com/palisade/option/calligraphy-only-design.png",
     },
   },
   {
@@ -221,8 +242,10 @@ const data = [
     },
     appliedOption: {
       id: 134,
+      category: "CONVENIENCE",
       name: "VIP 패키지",
       price: 5740000,
+      imgUrl: "https://h5-test-bucket.s3.ap-northeast-2.amazonaws.com/1.png",
     },
   },
 ];
@@ -231,13 +254,7 @@ type MyTrimSearchScreenProps = {
   $loading: boolean;
   $show: boolean;
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-  onSearch?: (appiedOption: AppliedOptionProps[], selected: number) => void;
-};
-
-type AppliedOptionProps = {
-  id: number;
-  name: string;
-  price: number;
+  onSearch?: (appiedOption: QuotationType[], selected: number) => void;
 };
 
 type IDDataProps = {
@@ -258,6 +275,7 @@ export default function MyTrimSearchScreen({
 }: MyTrimSearchScreenProps) {
   const [idData, setIdData] = useState<IDDataProps[]>([]);
   const [selected, setSelected] = useState<number | null>(null);
+  const { trimList } = useTrimState();
 
   const dataChange = (id: number, filter: IDDataProps) => {
     setSelected(null);
@@ -282,67 +300,51 @@ export default function MyTrimSearchScreen({
     if (isUnavailable) return { status: "none", isOption: "none" };
 
     for (const data of idData)
-      if (!data.additionalTrimIds.includes(trimId))
-        return { status: "default", isOption: "default" };
+      if (!data.defaultTrimIds.includes(trimId))
+        return { status: "default", isOption: "add" };
 
-    return { status: "default", isOption: "add" };
+    return { status: "default", isOption: "default" };
   };
 
   const onSearchHandler = (idData: IDDataProps[], selected: number) => {
     const appliedOptions = idData.map((optionData) => {
+      if (optionData.defaultTrimIds.includes(selected)) return null;
       const appliedOption = data.find(
         (option) => option.id === optionData.optionId
       )?.appliedOption;
       return appliedOption;
     });
 
-    onSearch && onSearch(appliedOptions as AppliedOptionProps[], selected);
+    const appliedOptionsFilter = appliedOptions.filter(
+      (option) => option !== null
+    );
+
+    onSearch &&
+      onSearch(appliedOptionsFilter as QuotationType[], selected);
   };
 
   return (
     <Container $loading={$loading} $show={$show} onClick={onClick}>
       <TrimSelectContainer>
-        <SearchTrimBox
-          name={"Exclusive"}
-          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
-          price={2000}
-          status={selected === 1 ? "choice" : CheckfilterOption(1).status}
-          isOption={CheckfilterOption(1).isOption}
-          onClick={
-            selected === 1 ? () => setSelected(null) : () => setSelected(1)
-          }
-        />
-        <SearchTrimBox
-          name={"Le Blanc"}
-          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
-          price={38960000}
-          status={selected === 2 ? "choice" : CheckfilterOption(2).status}
-          isOption={CheckfilterOption(2).isOption}
-          onClick={
-            selected === 2 ? () => setSelected(null) : () => setSelected(2)
-          }
-        />
-        <SearchTrimBox
-          name={"Prestige"}
-          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
-          price={38960000}
-          status={selected === 3 ? "choice" : CheckfilterOption(3).status}
-          isOption={CheckfilterOption(3).isOption}
-          onClick={
-            selected === 3 ? () => setSelected(null) : () => setSelected(3)
-          }
-        />
-
-        <SearchTrimBox
-          name={"Caligraphy"}
-          description={"실용적이고 기본적인 기능을 갖춘 베이직 트림"}
-          price={2000}
-          status={selected === 4 ? "choice" : CheckfilterOption(4).status}
-          isOption={CheckfilterOption(4).isOption}
-          onClick={
-            selected === 4 ? () => setSelected(null) : () => setSelected(4)
-          }
-        />
+        {trimList.map((trim) => (
+          <SearchTrimBox
+            key={trim.id}
+            name={trim.name}
+            description={trim.description}
+            price={trim.price}
+            status={
+              selected === trim.id
+                ? "choice"
+                : CheckfilterOption(trim.id).status
+            }
+            isOption={CheckfilterOption(trim.id).isOption}
+            onClick={
+              selected === trim.id
+                ? () => setSelected(null)
+                : () => setSelected(trim.id)
+            }
+          />
+        ))}
       </TrimSelectContainer>
       <CheckOptionContainer>
         {data.map((option) => (

--- a/FE-MyCarMaster/src/components/Main/view/ColorContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/ColorContent.tsx
@@ -20,8 +20,9 @@ function ColorContent() {
     <Container>
       <CategoryList
         categories={["외장색상", "내장색상"]}
-        onClickHandler={onClickHandler}
+        onClickHandler={(index) => onClickHandler(index as number)}
         indexSetter={4}
+        $switch={"colors"}
       />
       <ColorWrapper />
     </Container>

--- a/FE-MyCarMaster/src/components/Main/view/DetailModelContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/DetailModelContent.tsx
@@ -19,8 +19,9 @@ function DetailModelContent() {
     <Container>
       <CategoryList
         categories={["엔진", "구동방식", "바디타입"]}
-        onClickHandler={onClickHandler}
+        onClickHandler={(index) => onClickHandler(index as number)}
         indexSetter={1}
+        $switch={"detail"}
       />
       <DetailModelWrapper />
     </Container>

--- a/FE-MyCarMaster/src/components/Main/view/OptionContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/OptionContent.tsx
@@ -40,7 +40,11 @@ function OptionContent() {
         {/* API 완성 시, optionList[optionId].imgUrl 로 교체*/}
         <OptionDescription option={optionList[optionId - 1]} />
       </OptionContainer>
-      <CategoryList categories={categories} onClickHandler={onClickHandler} />
+      <CategoryList
+        categories={categories}
+        onClickHandler={(index) => onClickHandler(index as number)}
+        $switch={"option"}
+      />
     </Container>
   );
 }

--- a/FE-MyCarMaster/src/components/common/CategoryList/CategoryList.tsx
+++ b/FE-MyCarMaster/src/components/common/CategoryList/CategoryList.tsx
@@ -3,31 +3,60 @@ import CategoryItem from "./CategoryItem";
 import { useQuotationState } from "../../../contexts/QuotationContext";
 import { useOptionState } from "../../../contexts/OptionContext";
 
+type SwitchType = "detail" | "option" | "default" | "colors";
+type CategoryType =
+  | "파워트레인/성능"
+  | "지능형 안전기술"
+  | "안전"
+  | "외관"
+  | "내장"
+  | "시트"
+  | "편의";
+
 type CagetoryListProps = {
   categories: string[];
-  onClickHandler: (index: number) => void;
-  indexSetter?: number;
+  onClickHandler: (index?: number, category?: CategoryType | undefined) => void;
+  indexSetter?: number | CategoryType;
+  $switch?: SwitchType;
 };
 
 function CategoryList({
   categories,
   onClickHandler,
   indexSetter,
+  $switch,
 }: CagetoryListProps) {
   const { navigationId } = useQuotationState();
   const { optionCategoryId } = useOptionState();
+
+  const SwitchActive = (
+    switchType: SwitchType,
+    index?: number,
+    category?: CategoryType
+  ): boolean => {
+    switch (switchType) {
+      case "detail":
+      case "colors":
+        return index === navigationId - (indexSetter as number);
+      case "option":
+        return index === optionCategoryId;
+      default: // default
+        return category === indexSetter;
+    }
+  };
+
   return (
     <Container>
       {categories.map((category, index) => (
         <CategoryItem
           name={category}
           key={index}
-          $active={
-            indexSetter !== undefined
-              ? index === navigationId - indexSetter
-              : index === optionCategoryId
-          }
-          onClickHandler={() => onClickHandler(index)}
+          $active={SwitchActive(
+            $switch as SwitchType,
+            index,
+            category as CategoryType
+          )}
+          onClickHandler={() => onClickHandler(index, category as CategoryType)}
         />
       ))}
     </Container>

--- a/FE-MyCarMaster/src/components/common/OptionList/GridOptionList.tsx
+++ b/FE-MyCarMaster/src/components/common/OptionList/GridOptionList.tsx
@@ -1,0 +1,44 @@
+import {
+  GridContainer,
+  GridOptionItem,
+  GridOptionImage,
+  Text,
+  Detail,
+  GridOptionTextContainer,
+} from "./style";
+
+type ListType = {
+  id: number;
+  name: string;
+  imgUrl: string;
+  description: string;
+};
+
+type GridOptionListProps = {
+  list: ListType[];
+  handleClick?: (item: ListType) => void;
+};
+
+export default function GridOptionList({
+  list,
+  handleClick,
+}: GridOptionListProps) {
+  if (list.length === 0) {
+    return <>데이터가 존재하지 않습니다 ..</>;
+  }
+  return (
+    <GridContainer>
+      {list.map((item) => (
+        <GridOptionItem key={item.id}>
+          <GridOptionImage src={item.imgUrl} />
+          <GridOptionTextContainer>
+            <Text $size={0.875}>{item.name}</Text>
+            <Detail onClick={() => handleClick && handleClick(item)}>
+              자세히 보기 &gt;
+            </Detail>
+          </GridOptionTextContainer>
+        </GridOptionItem>
+      ))}
+    </GridContainer>
+  );
+}

--- a/FE-MyCarMaster/src/components/common/OptionList/OptionList.tsx
+++ b/FE-MyCarMaster/src/components/common/OptionList/OptionList.tsx
@@ -35,7 +35,7 @@ export default function OptionList({ $name }: OptionListProps) {
   return (
     <Container $isOpen={isOpen}>
       <ListContainer $isOpen={isOpen}>
-        <Text>{$name}</Text>
+        <Text $size={1.25}>{$name}</Text>
         <Icon $isOpen={true} onClick={() => setIsOpen(!isOpen)} />
       </ListContainer>
       <Line $isOpen={isOpen} $isFirst={isFirst.current} />

--- a/FE-MyCarMaster/src/components/common/OptionList/style.ts
+++ b/FE-MyCarMaster/src/components/common/OptionList/style.ts
@@ -55,14 +55,21 @@ export const Container = styled.div<{ $isOpen: boolean }>`
     margin: 0.875rem 0;
   }
 `;
-export const ListContainer = styled.div<{ $isOpen: boolean }>`
+export const ListContainer = styled.div<{ $isOpen?: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
 `;
 
-export const Text = styled.div`
-  font-size: 1.25rem;
+export const GridContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+`;
+
+export const Text = styled.div<{ $size?: number }>`
+  font-size: ${(props) => props.$size}rem;
 `;
 
 export const Icon = styled.div<{ $isOpen: boolean }>`
@@ -84,6 +91,34 @@ export const OptionItem = styled.div<{ $isOpen: boolean }>`
     css`
       animation: ${ListTextAppearAnimation} 1s ease-in-out forwards;
     `}
+`;
+
+export const GridOptionItem = styled.div`
+  width: 18%;
+  height: 40%;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${(props) => props.theme.colors.GREY2};
+`;
+
+export const GridOptionTextContainer = styled.div`
+  width: 100%;
+  height: 5.5rem;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  justify-content: space-between;
+`;
+
+export const GridOptionImage = styled.img`
+  width: 100%;
+  height: 8rem;
+  object-fit: cover;
+`;
+
+export const Detail = styled.p`
+  display: flex;
+  font-size: 0.75rem;
 `;
 
 export const Line = styled.div<{ $isOpen: boolean; $isFirst: boolean }>`


### PR DESCRIPTION
## 개요
- #247 

## 작업사항
- 기본 옵션 보기 레이아웃을 구성하고, 동적 데이터를 다룰 수 있다.
- 기본 옵션 보기 레이아웃의 자세히보기를 클릭할 경우 모달로 이동해야 한다. (현재, 콘솔로 찍어 놓은 부분)


https://github.com/softeerbootcamp-2nd/H5-MyCarMaster/assets/82306066/2fecbdb4-0574-4f44-bdcd-83733c9cf13d

```jsx
// DefaultOptionScreen.tsx
export default function DefaultOptionScreen() {
...

const handleClick = (item: ListType) => {
    console.log(item);
    // 여기에 모달 띄어주는 이벤트 및 달아주면 됩니다.
    // 데이터는 item에 들어가 있습니다.
  };

}
```