### PR TITLE
[Feature] 트림의 모든 기본 옵션 목록 조회 기능 구현

### DIFF
--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/trim/dto/response/GetTrimDefaultOptionsResponse.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/trim/dto/response/GetTrimDefaultOptionsResponse.java
@@ -2,7 +2,6 @@ package softeer.be_my_car_master.api.trim.dto.response;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,10 +18,9 @@ public class GetTrimDefaultOptionsResponse {
 
 	private List<TrimDefaultOptionDto> defaultOptions;
 
-	public GetTrimDefaultOptionsResponse from(List<Option> defaultOptions, List<String> needs) {
-
-		List<TrimDefaultOptionDto> trimDefaultOptionDtos = IntStream.range(0, defaultOptions.size())
-			.mapToObj(i -> TrimDefaultOptionDto.from(defaultOptions.get(i), needs.get(i)))
+	public static GetTrimDefaultOptionsResponse from(List<Option> defaultOptions) {
+		List<TrimDefaultOptionDto> trimDefaultOptionDtos = defaultOptions.stream()
+			.map(TrimDefaultOptionDto::from)
 			.collect(Collectors.toList());
 		return new GetTrimDefaultOptionsResponse(trimDefaultOptionDtos);
 	}

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/trim/dto/response/TrimDefaultOptionDto.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/trim/dto/response/TrimDefaultOptionDto.java
@@ -29,17 +29,13 @@ public class TrimDefaultOptionDto {
 	@Schema(description = "옵션 설명", example = "null")
 	private String description;
 
-	@Schema(description = "해당 옵션 제공에 필요한 세부모델명", example = "null")
-	private String need;
-
-	public static TrimDefaultOptionDto from(Option option, String need) {
+	public static TrimDefaultOptionDto from(Option option) {
 		return TrimDefaultOptionDto.builder()
 			.id(option.getId())
 			.category(option.getCategoryValue())
 			.name(option.getName())
 			.imgUrl(option.getImgUrl())
 			.description(option.getDescription())
-			.need(need)
 			.build();
 	}
 }

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/trim/usecase/GetTrimDefaultOptionsUseCase.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/api/trim/usecase/GetTrimDefaultOptionsUseCase.java
@@ -1,14 +1,21 @@
 package softeer.be_my_car_master.api.trim.usecase;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+import softeer.be_my_car_master.api.option.usecase.port.OptionPort;
 import softeer.be_my_car_master.api.trim.dto.response.GetTrimDefaultOptionsResponse;
+import softeer.be_my_car_master.domain.option.Option;
 import softeer.be_my_car_master.global.annotation.UseCase;
 
 @UseCase
 @RequiredArgsConstructor
 public class GetTrimDefaultOptionsUseCase {
 
+	private final OptionPort optionPort;
+
 	public GetTrimDefaultOptionsResponse execute(Long trimId) {
-		return null;
+		List<Option> defaultOptions = optionPort.findDefaultOptionsByTrimId(trimId);
+		return GetTrimDefaultOptionsResponse.from(defaultOptions);
 	}
 }

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/trim/controller/TrimControllerTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/trim/controller/TrimControllerTest.java
@@ -136,7 +136,6 @@ class TrimControllerTest {
 				.name("HTRAC")
 				.imgUrl("imgUrl")
 				.description("옵션 상세설명")
-				.need("4WD")
 				.build();
 			getTrimDefaultOptionsResponse.setDefaultOptions(Arrays.asList(trimDefaultOptionDto));
 

--- a/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/trim/usecase/GetTrimDefaultOptionsUseCaseTest.java
+++ b/BE-MyCarMaster/src/test/java/softeer/be_my_car_master/api/trim/usecase/GetTrimDefaultOptionsUseCaseTest.java
@@ -1,0 +1,62 @@
+package softeer.be_my_car_master.api.trim.usecase;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import softeer.be_my_car_master.api.option.usecase.port.OptionPort;
+import softeer.be_my_car_master.api.trim.dto.response.GetTrimDefaultOptionsResponse;
+import softeer.be_my_car_master.api.trim.dto.response.TrimDefaultOptionDto;
+import softeer.be_my_car_master.domain.option.Category;
+import softeer.be_my_car_master.domain.option.Option;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetTrimDefaultOptionsUseCase Test")
+public class GetTrimDefaultOptionsUseCaseTest {
+
+	@InjectMocks
+	private GetTrimDefaultOptionsUseCase getTrimDefaultOptionsUseCase;
+
+	@Mock
+	private OptionPort optionPort;
+
+	@Test
+	@DisplayName("트림의 기본 옵션 목록을 조회합니다")
+	void execute() {
+		// given
+		Option option = Option.builder()
+			.id(1L)
+			.name("임의의 옵션")
+			.category(Category.SAFE)
+			.description("옵션 상세설명")
+			.imgUrl("imgUrl")
+			.build();
+
+		given(optionPort.findDefaultOptionsByTrimId(any())).willReturn(List.of(option));
+
+		// when
+		GetTrimDefaultOptionsResponse getTrimDefaultOptionsResponse = getTrimDefaultOptionsUseCase.execute(1L);
+
+		// then
+		List<TrimDefaultOptionDto> trimDefaultOptions = getTrimDefaultOptionsResponse.getDefaultOptions();
+		TrimDefaultOptionDto optionExpected = trimDefaultOptions.get(0);
+
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(trimDefaultOptions).isNotNull();
+			softAssertions.assertThat(trimDefaultOptions).hasSize(1);
+			softAssertions.assertThat(optionExpected.getId()).isEqualTo(option.getId());
+			softAssertions.assertThat(optionExpected.getName()).isEqualTo(option.getName());
+			softAssertions.assertThat(optionExpected.getCategory()).isEqualTo(option.getCategoryValue());
+			softAssertions.assertThat(optionExpected.getDescription()).isEqualTo(option.getDescription());
+			softAssertions.assertThat(optionExpected.getImgUrl()).isEqualTo(option.getImgUrl());
+		});
+	}
+}


### PR DESCRIPTION
## 개요
- #204 

## 작업사항
- GetTrimDefaultOptionsUseCase 구현 및 TC 추가
- 기획 변경 (API Spec 변경)에 따른 Dto 수정

## 고민사항
- 오늘 이야기 했던 기획 (기본 옵션 제공에 필요한 세부모델명 넘기기)는 추후 추가하기로 함.
    - 구동방식/엔진/바디타입별 선택'불'가능한 옵션 테이블만 존재해서 구현하는데 시간이 오래 걸릴 것 같음 / 복잡
    - 일단 빠르게 기능구현하고 추후 추가할 예정
