### PR TITLE
[FE-Refactor] 컴포넌트 Style 재정리

### DIFF
--- a/FE-MyCarMaster/src/App.tsx
+++ b/FE-MyCarMaster/src/App.tsx
@@ -42,7 +42,7 @@ function App() {
           QuotationProvider,
         ]}
       >
-        <Flex>
+        <Flex $overflow="hidden">
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/estimation" element={<Estimation />} />

--- a/FE-MyCarMaster/src/components/Footer/FoldScreen.tsx
+++ b/FE-MyCarMaster/src/components/Footer/FoldScreen.tsx
@@ -1,16 +1,15 @@
 import React, { useState } from "react";
 import { createPortal } from "react-dom";
 import styled from "styled-components";
-import AngleUp from "../../assets/icons/AngleUp.svg";
-import AngleDown from "../../assets/icons/AngleDown.svg";
+import AngleUp from "@assets/icons/AngleUp.svg";
+import AngleDown from "@assets/icons/AngleDown.svg";
 import MyTrimSearchScreen from "./screen_view/MyTrimSearchScreen";
 import DefaultOptionScreen from "./screen_view/DefaultOptionScreen";
-import { QuotationType } from "../../types/quotation.types";
-import { useTrimState, useTrimDispatch } from "../../contexts/TrimContext";
-import { useQuotationDispatch } from "../../contexts/QuotationContext";
-import SnackBar from "../common/SnackBar/SnackBar";
-import { Modals } from "../common/Modals/Modals";
-import { ModalType } from "../../constants/Modal.constants";
+import { QuotationType } from "types/quotation.types";
+import { useTrimState, useTrimDispatch } from "@contexts/TrimContext";
+import { useQuotationDispatch } from "@contexts/QuotationContext";
+import { SnackBar, Modals } from "@common/index";
+import { ModalType } from "@constants/Modal.constants";
 
 type FoldScreenProps = {
   text: string;

--- a/FE-MyCarMaster/src/components/Footer/Footer.tsx
+++ b/FE-MyCarMaster/src/components/Footer/Footer.tsx
@@ -1,16 +1,17 @@
-import styled from "styled-components";
-import SelectListWrapper from "./SelectListWrapper";
-import Button from "../common/Button/Button";
-import theme from "../../styles/Theme";
-import FoldScreen from "./FoldScreen";
+import { useNavigate } from "react-router-dom";
+import { Flex } from "@styles/core.style";
+import { Container, HeadText, DescriptionText } from "./style";
 import {
   useQuotationState,
   useQuotationDispatch,
-} from "../../contexts/QuotationContext";
-import indexNameSwitching from "../../utils/indexNameSwitching";
-import { useNavigate } from "react-router-dom";
+} from "@contexts/QuotationContext";
+import { Button } from "@common/index";
+import theme from "@styles/Theme";
+import SelectListWrapper from "./SelectListWrapper";
+import FoldScreen from "./FoldScreen";
+import indexNameSwitching from "@utils/indexNameSwitching";
 
-function Footer() {
+export default function Footer() {
   const { navigationId, isFirst } = useQuotationState();
   const quotationDispatch = useQuotationDispatch();
   const name = indexNameSwitching(navigationId) as string;
@@ -42,17 +43,25 @@ function Footer() {
   return (
     <Container>
       <SelectListWrapper />
-      <RightContainer>
-        <HeightFittingContainer>
-          <TextContainer>
+      <Flex $width="12rem" $flexDirection="column">
+        <Flex
+          $height="10.25rem"
+          $flexDirection="column"
+          $justifyContent="space-between"
+        >
+          <Flex $flexDirection="column">
             {name && (
               <>
                 <HeadText>{name} 선택</HeadText>
                 <DescriptionText>원하는 {name}을 선택해주세요.</DescriptionText>
               </>
             )}
-          </TextContainer>
-          <ButtonContainer>
+          </Flex>
+          <Flex
+            $flexDirection="column"
+            $gap="0.25rem"
+            $justifyContent="flex-end"
+          >
             {navigationId !== 0 && (
               <Button
                 $x={12}
@@ -78,9 +87,9 @@ function Footer() {
                   : () => buttonHandler(1)
               }
             />
-          </ButtonContainer>
-        </HeightFittingContainer>
-      </RightContainer>
+          </Flex>
+        </Flex>
+      </Flex>
       {navigationId === 0 && (
         <FoldScreen text={"내게 맞는 트림 찾기"} $switch={"searchTrim"} />
       )}
@@ -90,56 +99,3 @@ function Footer() {
     </Container>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  position: relative;
-  width: 100%;
-  gap: 10rem;
-  height: 30rem;
-  padding: 2rem 0rem;
-  background-color: ${({ theme }) => theme.colors.GREY1};
-`;
-
-const RightContainer = styled.div`
-  width: 12rem;
-  display: flex;
-  flex-direction: column;
-`;
-
-const TextContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-`;
-
-const HeadText = styled.p`
-  font-size: 1.5rem;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 1.5rem;
-`;
-
-const DescriptionText = styled.p`
-  font-size: 0.9rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 165%;
-`;
-
-const ButtonContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-`;
-
-const HeightFittingContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 10.25rem;
-`;
-
-export default Footer;

--- a/FE-MyCarMaster/src/components/Footer/SelectListWrapper.tsx
+++ b/FE-MyCarMaster/src/components/Footer/SelectListWrapper.tsx
@@ -1,14 +1,15 @@
-import TrimContent from "./view/TrimSelect";
-import DetailModelSelect from "./view/DetailModelSelect";
-import OptionSelect from "./view/OptionSelect";
-import ColorSelect from "./view/ColorSelect";
+import {
+  TrimSelect,
+  DetailModelSelect,
+  ColorSelect,
+  OptionSelect,
+} from "./view/index";
 import { useQuotationState } from "../../contexts/QuotationContext";
-
 
 export default function SelectListWrapper() {
   const { navigationId } = useQuotationState();
 
-  if (navigationId === 0) return <TrimContent />;
+  if (navigationId === 0) return <TrimSelect />;
   if (navigationId >= 1 && navigationId <= 3) return <DetailModelSelect />;
   if (navigationId >= 4 && navigationId <= 5) return <ColorSelect />;
   if (navigationId === 6) return <OptionSelect />;

--- a/FE-MyCarMaster/src/components/Footer/screen_view/DefaultOptionScreen.tsx
+++ b/FE-MyCarMaster/src/components/Footer/screen_view/DefaultOptionScreen.tsx
@@ -1,13 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
-import CategoryList from "../../common/CategoryList/CategoryList";
-import GridOptionList from "../../common/OptionList/GridOptionList";
-import useFetch from "../../../hooks/useFetch";
-import { useEffect } from "react";
-import { useTrimState } from "../../../contexts/TrimContext";
-import { useDetailState } from "../../../contexts/DetailContext";
-import ArrowLeft from "../../../assets/icons/ArrowLeft.svg";
-import ArrowRight from "../../../assets/icons/ArrowRight.svg";
+import { CategoryList, GridOptionList } from "@common/index";
+import { useTrimState } from "@contexts/TrimContext";
+import { useDetailState } from "@contexts/DetailContext";
+import ArrowLeft from "@assets/icons/ArrowLeft.svg";
+import ArrowRight from "@assets/icons/ArrowRight.svg";
+import useFetch from "@hooks/useFetch";
 
 type DataListProps = {
   id: number;

--- a/FE-MyCarMaster/src/components/Footer/screen_view/MyTrimSearchScreen.tsx
+++ b/FE-MyCarMaster/src/components/Footer/screen_view/MyTrimSearchScreen.tsx
@@ -1,16 +1,17 @@
+import { Fragment, useState, useEffect } from "react";
 import styled from "styled-components";
-import SearchTrimBox from "../../common/SearchTrimBox/SearchTrimBox";
-import OptionCheckBox from "../../common/CheckBox/OptionCheckBox";
-import Button from "../../common/Button/Button";
-import { Fragment, useState } from "react";
-import theme from "../../../styles/Theme";
-import { useTrimState } from "../../../contexts/TrimContext";
-import { QuotationType } from "../../../types/quotation.types";
-import { DescriptionOptionModalProps } from "../../../types/options.types";
-import OptionDescriptionModal from "../../common/OptionDescriptionModal/OptionDescriptionModal";
-import useFetch from "../../../hooks/useFetch";
-import { useEffect } from "react";
-import { useModelState } from "../../../contexts/ModelContext";
+import theme from "@styles/Theme";
+import {
+  SearchTrimBox,
+  OptionCheckBox,
+  Button,
+  OptionDescriptionModal,
+} from "@common/index";
+import { useModelState } from "@contexts/ModelContext";
+import { useTrimState } from "@contexts/TrimContext";
+import { QuotationType } from "types/quotation.types";
+import { DescriptionOptionModalProps } from "types/options.types";
+import useFetch from "@hooks/useFetch";
 
 type DataListProps = {
   id: number;

--- a/FE-MyCarMaster/src/components/Footer/view/ColorSelect.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/ColorSelect.tsx
@@ -1,31 +1,23 @@
-import styled from "styled-components";
-import { useQuotationState } from "../../../contexts/QuotationContext";
+import { Flex } from "@styles/core.style";
+import { useQuotationState } from "@/contexts/QuotationContext";
 import ExteriorColorSelectView from "./ColorView/ExteriorColorSelectView";
 import InteriorColorSelectView from "./ColorView/InteriorColorSelectView";
 
 export default function TrimSelect() {
   const { navigationId } = useQuotationState();
   return (
-    <>
+    <Flex $justifyContent="center" $width="59.5rem">
       {navigationId === 4 && (
-        <Container>
+        <Flex $gap="0.5rem" $wrap={true}>
           <ExteriorColorSelectView />
-        </Container>
+        </Flex>
       )}
 
       {navigationId === 5 && (
-        <Container>
+        <Flex $gap="0.5rem" $wrap={true}>
           <InteriorColorSelectView />
-        </Container>
+        </Flex>
       )}
-    </>
+    </Flex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 59.5rem;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-`;

--- a/FE-MyCarMaster/src/components/Footer/view/ColorView/ExteriorColorSelectView.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/ColorView/ExteriorColorSelectView.tsx
@@ -1,13 +1,13 @@
-import OuterColorBox from "../../../common/ColorBox/OuterColorBox";
+import { OuterColorBox } from "@common/index";
 import {
   useCarPaintState,
   useCarPaintDispatch,
-} from "../../../../contexts/CarPaintContext";
+} from "@contexts/CarPaintContext";
 import {
   useQuotationState,
   useQuotationDispatch,
-} from "../../../../contexts/QuotationContext";
-import { TrimQuotationType } from "../../../../types/quotation.types";
+} from "@contexts/QuotationContext";
+import { TrimQuotationType } from "types/quotation.types";
 
 export default function InteriorColorSelectView() {
   const { exteriorList, exteriorId } = useCarPaintState();

--- a/FE-MyCarMaster/src/components/Footer/view/ColorView/InteriorColorSelectView.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/ColorView/InteriorColorSelectView.tsx
@@ -1,13 +1,13 @@
-import InnerColorBox from "../../../common/ColorBox/InnerColorBox";
+import { InnerColorBox } from "@common/index";
 import {
   useCarPaintState,
   useCarPaintDispatch,
-} from "../../../../contexts/CarPaintContext";
+} from "@contexts/CarPaintContext";
 import {
   useQuotationState,
   useQuotationDispatch,
-} from "../../../../contexts/QuotationContext";
-import { TrimQuotationType } from "../../../../types/quotation.types";
+} from "@contexts/QuotationContext";
+import { TrimQuotationType } from "types/quotation.types";
 
 export default function InteriorColorSelectView() {
   const { interiorList, interiorId } = useCarPaintState();

--- a/FE-MyCarMaster/src/components/Footer/view/DetailModelSelect.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/DetailModelSelect.tsx
@@ -1,24 +1,19 @@
-import styled from "styled-components";
-import { useQuotationState } from "../../../contexts/QuotationContext";
-import BodyTypeSelectView from "./DetailModelView/BodyTypeSelectView";
-import EngineSelectView from "./DetailModelView/EngineSelectView";
-import WheelDriveSelectView from "./DetailModelView/WheelDriveSelectView";
+import { Flex } from "@styles/core.style";
+import { useQuotationState } from "@contexts/QuotationContext";
+import {
+  BodyTypeSelectView,
+  EngineSelectView,
+  WheelDriveSelectView,
+} from "./DetailModelView/index";
 
 export default function DetailModelSelect() {
   const { navigationId } = useQuotationState();
 
   return (
-    <Container>
+    <Flex $width="59.5rem" $gap="0.5rem">
       {navigationId === 1 && <EngineSelectView />}
       {navigationId === 2 && <WheelDriveSelectView />}
       {navigationId === 3 && <BodyTypeSelectView />}
-    </Container>
+    </Flex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 59.5rem;
-  gap: 0.5rem;
-`;

--- a/FE-MyCarMaster/src/components/Footer/view/DetailModelView/BodyTypeSelectView.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/DetailModelView/BodyTypeSelectView.tsx
@@ -1,12 +1,9 @@
-import {
-  useDetailState,
-  useDetailDispatch,
-} from "../../../../contexts/DetailContext";
-import { useQuotationDispatch } from "../../../../contexts/QuotationContext";
-import OptionBox from "../../../common/OptionBox/OptionBox";
+import { useDetailState, useDetailDispatch } from "@contexts/DetailContext";
+import { useQuotationDispatch } from "@contexts/QuotationContext";
+import { OptionBox } from "@common/index";
 
 export default function BodyTypeSelectView() {
-  const { bodyTypeList,  bodyTypeId } = useDetailState();
+  const { bodyTypeList, bodyTypeId } = useDetailState();
   const detailDispatch = useDetailDispatch();
   const quotationDispatch = useQuotationDispatch();
 

--- a/FE-MyCarMaster/src/components/Footer/view/DetailModelView/EngineSelectView.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/DetailModelView/EngineSelectView.tsx
@@ -1,19 +1,15 @@
 import { Fragment, useState } from "react";
-import {
-  useDetailState,
-  useDetailDispatch,
-} from "../../../../contexts/DetailContext";
+import { useDetailState, useDetailDispatch } from "@contexts/DetailContext";
 import {
   useQuotationDispatch,
   useQuotationState,
-} from "../../../../contexts/QuotationContext";
-import { useOptionState } from "../../../../contexts/OptionContext";
-import { useTrimState } from "../../../../contexts/TrimContext";
-import OptionBox from "../../../common/OptionBox/OptionBox";
-import { Modals } from "../../../common/Modals/Modals";
-import { ModalType } from "../../../../constants/Modal.constants";
-import { get } from "../../../../utils/fetch";
-import { UnselectableOptionProps } from "../../../../types/options.types";
+} from "@contexts/QuotationContext";
+import { useOptionState } from "@contexts/OptionContext";
+import { useTrimState } from "@contexts/TrimContext";
+import { OptionBox, Modals } from "@common/index";
+import { ModalType } from "@constants/Modal.constants";
+import { UnselectableOptionProps } from "types/options.types";
+import { get } from "@utils/fetch";
 
 export default function BodyTypeSelectView() {
   const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;

--- a/FE-MyCarMaster/src/components/Footer/view/DetailModelView/WheelDriveSelectView.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/DetailModelView/WheelDriveSelectView.tsx
@@ -1,9 +1,6 @@
-import {
-  useDetailState,
-  useDetailDispatch,
-} from "../../../../contexts/DetailContext";
-import { useQuotationDispatch } from "../../../../contexts/QuotationContext";
-import OptionBox from "../../../common/OptionBox/OptionBox";
+import { useDetailState, useDetailDispatch } from "@contexts/DetailContext";
+import { useQuotationDispatch } from "@contexts/QuotationContext";
+import { OptionBox } from "@common/index";
 
 export default function BodyTypeSelectView() {
   const { wheelDriveList, wheelDriveId } = useDetailState();

--- a/FE-MyCarMaster/src/components/Footer/view/OptionSelect.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/OptionSelect.tsx
@@ -1,20 +1,20 @@
-import styled from "styled-components";
-import {
-  useOptionDispatch,
-  useOptionState,
-} from "../../../contexts/OptionContext";
-import { useQuotationState } from "../../../contexts/QuotationContext";
-import OptionBox from "../../common/OptionBox/OptionBox";
 import { useEffect, useState } from "react";
-import { OptionType } from "../../../types/options.types";
-import filterOptionCategory from "../../../utils/Option/filterOptionCategory";
-import { categories } from "../../../constants/Option.constants";
+import { BlurFlex, OptionFlex, ScrollButton } from "./style";
+import { useOptionDispatch, useOptionState } from "@contexts/OptionContext";
+import { useQuotationState } from "@contexts/QuotationContext";
+import { categories } from "@constants/Option.constants";
+import { OptionBox } from "@common/index";
+import filterOptionCategory from "@utils/Option/filterOptionCategory";
+import { OptionType } from "types/options.types";
+import ArrowRightLong from "@assets/icons/ArrowRightLong.svg";
+import ArrowLeftLong from "@assets/icons/ArrowLeftLong.svg";
 
 export default function OptionSelect() {
   const { optionList, selectedOption, consideredOption, optionCategoryId } =
     useOptionState();
   const [isTrimCheckOption, setIsTrimCheckOption] = useState<boolean>(false);
   const { optionQuotation } = useQuotationState();
+  // const [current, setCurrent] = useState<number>(0);
   const optionDispatch = useOptionDispatch();
 
   const [filteredOptionList, setFilteredOptionList] =
@@ -55,38 +55,63 @@ export default function OptionSelect() {
     });
   };
 
+  const handleScroll = (e: React.WheelEvent<HTMLDivElement>) => {
+    const target = e.currentTarget;
+    console.log(target);
+    const scrollAmount = e.deltaY;
+    target.scrollTo({
+      top: 0,
+      left: target.scrollLeft + scrollAmount,
+      behavior: "smooth",
+    });
+    // setCurrent(target.scrollLeft);
+  };
+
+  const handleScrollButton = (direction: string) => {
+    const target = document.querySelector(".option-box") as HTMLDivElement;
+    const scrollAmount = direction === "left" ? -230 : 230;
+    target.scrollTo({
+      top: 0,
+      left: target.scrollLeft + scrollAmount,
+      behavior: "smooth",
+    });
+    // setCurrent(target.scrollLeft);
+  };
+
   return (
-    <Container>
-      {isTrimCheckOption &&
-        filteredOptionList?.length &&
-        filteredOptionList.map((option, index) => {
-          return (
-            <OptionBox
-              key={index}
-              $id={option.id}
-              $name={option.name}
-              $description={option.description}
-              $ratio={option.ratio}
-              $price={option.price}
-              $switch="option"
-              $choice={selectedOption.includes(option.id)}
-              $considered={consideredOption.includes(option.id)}
-              handleClick={() => changeOptionId(option.id)}
-            />
-          );
-        })}
-    </Container>
+    <BlurFlex $width="59.5rem" $justifyContent="center" $position="relative">
+      <OptionFlex $gap="0.5rem" onWheel={handleScroll} className="option-box">
+        {isTrimCheckOption &&
+          filteredOptionList?.length &&
+          filteredOptionList.map((option, index) => {
+            return (
+              <OptionBox
+                key={index}
+                $id={option.id}
+                $name={option.name}
+                $description={option.description}
+                $ratio={option.ratio}
+                $price={option.price}
+                $switch="option"
+                $choice={selectedOption.includes(option.id)}
+                $considered={consideredOption.includes(option.id)}
+                handleClick={() => changeOptionId(option.id)}
+              />
+            );
+          })}
+      </OptionFlex>
+      <ScrollButton
+        $direction="left"
+        onClick={() => handleScrollButton("left")}
+      >
+        <img src={ArrowLeftLong} alt="arrow-left" />
+      </ScrollButton>
+      <ScrollButton
+        $direction="right"
+        onClick={() => handleScrollButton("right")}
+      >
+        <img src={ArrowRightLong} alt="arrow-right" />
+      </ScrollButton>
+    </BlurFlex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 59.5rem;
-  gap: 0.5rem;
-  overflow: hidden;
-  overflow-x: scroll;
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`;

--- a/FE-MyCarMaster/src/components/Footer/view/TrimSelect.tsx
+++ b/FE-MyCarMaster/src/components/Footer/view/TrimSelect.tsx
@@ -1,15 +1,13 @@
 import React, { Fragment, useState } from "react";
-import styled from "styled-components";
-import { useTrimState, useTrimDispatch } from "../../../contexts/TrimContext";
+import { Flex } from "@styles/core.style";
+import { useTrimState, useTrimDispatch } from "@contexts/TrimContext";
 import {
   useQuotationDispatch,
   useQuotationState,
-} from "../../../contexts/QuotationContext";
-import OptionBox from "../../common/OptionBox/OptionBox";
-import { Modals } from "../../common/Modals/Modals";
-import { ModalType } from "../../../constants/Modal.constants";
-import BasicOptionModal from "../../common/BasicOptionModal/BasicOptionModal";
-import { Trims } from "../../../types/trim.types";
+} from "@contexts/QuotationContext";
+import { OptionBox, Modals, BasicOptionModal } from "@common/index";
+import { ModalType } from "@constants/Modal.constants";
+import { Trims } from "types/trim.types";
 
 export default function TrimSelect() {
   const { trimList, trimId } = useTrimState();
@@ -61,7 +59,12 @@ export default function TrimSelect() {
     setIsBasicOptionModalOpen(true);
   };
 
-  if (!trimList.length) return <Container>데이터가 없습니다.</Container>;
+  if (!trimList.length)
+    return (
+      <Flex $width="59.5rem" $gap="0.5rem">
+        데이터가 없습니다.
+      </Flex>
+    );
   const reselectTrim = (id: number) => {
     quotationDispatch({ type: "RESET_QUOTATION" });
     selectTrim(id);
@@ -70,7 +73,7 @@ export default function TrimSelect() {
 
   return (
     <Fragment>
-      <Container>
+      <Flex $width="59.5rem" $gap="0.5rem">
         {trimList?.length &&
           trimList.map((trim) => {
             return (
@@ -100,7 +103,7 @@ export default function TrimSelect() {
             setIsBasicOptionModalOpen={setIsBasicOptionModalOpen}
           />
         )}
-      </Container>
+      </Flex>
       {isOpen && (
         <Modals
           type={ModalType.CHANGE_TRIM}
@@ -111,10 +114,3 @@ export default function TrimSelect() {
     </Fragment>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 59.5rem;
-  gap: 0.5rem;
-`;

--- a/FE-MyCarMaster/src/components/Header/Header.tsx
+++ b/FE-MyCarMaster/src/components/Header/Header.tsx
@@ -1,12 +1,12 @@
-import styled from "styled-components";
-import ArrowBottom from "../../assets/icons/ArrowBottom.svg";
-import white_logo from "../../assets/images/white_logo.svg";
-import dark_logo from "../../assets/images/dark_logo.svg";
-import { useModelState } from "../../contexts/ModelContext";
-import { useNavigate } from "react-router-dom";
 import { Fragment, useState } from "react";
-import { Modals } from "../common/Modals/Modals";
-import { ModalType } from "../../constants/Modal.constants";
+import { useNavigate } from "react-router-dom";
+import ArrowBottom from "@assets/icons/ArrowBottom.svg";
+import white_logo from "@assets/images/white_logo.svg";
+import dark_logo from "@assets/images/dark_logo.svg";
+import { useModelState } from "@contexts/ModelContext";
+import { Modals } from "@common/index";
+import { ModalType } from "@constants/Modal.constants";
+import { Container, Img, ModelSelector, ModelName, ModelButton } from "./style";
 
 type HeaderProps = {
   isHome: boolean;
@@ -60,38 +60,5 @@ function Header({ isHome, logo, status }: HeaderProps) {
     </Fragment>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  min-height: 7.5rem;
-  margin: 0 3%;
-  gap: 60rem;
-`;
-
-const Img = styled.img`
-  width: 20%;
-  min-width: 12rem;
-  max-width: 16rem;
-  z-index: 100;
-  cursor: pointer;
-`;
-
-const ModelSelector = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-`;
-
-const ModelName = styled.div`
-  font-size: 1.2rem;
-  font-weight: 500;
-  color: ${({ theme }) => theme.colors.NAVYBLUE5};
-`;
-
-const ModelButton = styled.img`
-  cursor: pointer;
-`;
 
 export default Header;

--- a/FE-MyCarMaster/src/components/Home/ModelSelectView.tsx
+++ b/FE-MyCarMaster/src/components/Home/ModelSelectView.tsx
@@ -1,10 +1,17 @@
 import { useState } from "react";
-import theme from "../../styles/Theme";
-import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import CategoryList from "../common/CategoryList/CategoryList";
-import Button from "../common/Button/Button";
+import theme from "@styles/Theme";
+import { CategoryList, Button } from "@common/index";
 import ModelBox from "./ModelBox";
+import {
+  Container,
+  TopContainer,
+  ModelContainer,
+  ButtonContainer,
+  Text,
+  NotFoundText,
+} from "./style";
+import { typeData } from "@constants/Model.constatns";
 
 const data = {
   model: [
@@ -67,24 +74,6 @@ const data = {
   ],
 };
 
-const typeData = [
-  "전체",
-  "수소 / 전기차",
-  "N",
-  "승용",
-  "SUV",
-  "MPV",
-  "소형트럭&택시",
-  "트럭",
-  "버스",
-];
-
-type TextProp = {
-  $color?: string;
-  $animation?: boolean;
-  $delay?: number;
-};
-
 type HomeProp = {
   isFold: boolean;
 };
@@ -128,17 +117,7 @@ export default function Home({ isFold }: HomeProp) {
         </Text>
 
         <CategoryList
-          categories={[
-            "전체",
-            "수소 / 전기차",
-            "N",
-            "승용",
-            "SUV",
-            "MPV",
-            "소형트럭&택시",
-            "트럭",
-            "버스",
-          ]}
+          categories={typeData}
           onClickHandler={(index) => setCategorySelect(index as number)}
           indexSetter={categorySelect}
           $switch="model"
@@ -177,66 +156,3 @@ export default function Home({ isFold }: HomeProp) {
     </Container>
   );
 }
-
-const Container = styled.div<{ $animation?: boolean }>`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-
-  margin: 2rem 0;
-
-  animation: ${({ $animation }) =>
-    $animation ? "homeAppear 2s ease-in-out forwards" : ""};
-
-  @keyframes homeAppear {
-    0% {
-      opacity: 0;
-    }
-    100% {
-      opacity: 1;
-    }
-  }
-`;
-
-const TopContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-const ModelContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-
-  gap: 1rem;
-`;
-
-const ButtonContainer = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-`;
-
-const Text = styled.p<TextProp>`
-  ${(props) => props.theme.fonts.Display}
-  text-align: left;
-  color: ${(props) => props.$color || "#FFFFFF"};
-
-  @media screen and (max-width: 1400px) {
-    font-size: 0;
-  }
-`;
-
-const NotFoundText = styled.p`
-  ${(props) => props.theme.fonts.ContentMedium1}
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;

--- a/FE-MyCarMaster/src/components/Main/MainView.tsx
+++ b/FE-MyCarMaster/src/components/Main/MainView.tsx
@@ -1,29 +1,15 @@
-import styled from "styled-components";
 import MainWrapper from "./MainWrapper";
-import NavigationList from "../common/NavigationList/NavigationList";
+import { MainContent } from "./style";
+import { NavigationList } from "@common/index";
+import { Flex } from "@styles/core.style";
 
-function MainView() {
+export default function MainView() {
   return (
-    <Container>
+    <Flex $gap={"10rem"} $justifyContent="center" >
       <MainContent>
         <MainWrapper />
       </MainContent>
       <NavigationList confirm={false} />
-    </Container>
+    </Flex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  gap: 10rem;
-  height: 100%;
-  width: 100%;
-`;
-
-const MainContent = styled.div`
-  width: 59.5rem;
-`;
-
-export default MainView;

--- a/FE-MyCarMaster/src/components/Main/MainWrapper.tsx
+++ b/FE-MyCarMaster/src/components/Main/MainWrapper.tsx
@@ -1,10 +1,12 @@
-import TrimContent from "./view/TrimContent";
-import DetailModelContent from "./view/DetailModelContent";
-import ColorContent from "./view/ColorContent";
-import OptionContent from "./view/OptionContent";
-import { useQuotationState } from "../../contexts/QuotationContext";
+import {
+  TrimContent,
+  DetailModelContent,
+  ColorContent,
+  OptionContent,
+} from "./view/index";
+import { useQuotationState } from "@contexts/QuotationContext";
 
-function MainWrapper() {
+export default function MainWrapper() {
   const { navigationId } = useQuotationState();
   if (navigationId === 0) return <TrimContent />;
   if (navigationId >= 1 && navigationId <= 3) return <DetailModelContent />;
@@ -12,5 +14,3 @@ function MainWrapper() {
   if (navigationId === 6) return <OptionContent />;
   return <></>;
 }
-
-export default MainWrapper;

--- a/FE-MyCarMaster/src/components/Main/view/ColorContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/ColorContent.tsx
@@ -1,9 +1,9 @@
-import { styled } from "styled-components";
-import CategoryList from "../../common/CategoryList/CategoryList";
+import { Flex } from "@styles/core.style";
+import { CategoryList } from "@common/index";
 import ColorWrapper from "./ColorView/ColorWrapper";
-import { useQuotationDispatch } from "../../../contexts/QuotationContext";
+import { useQuotationDispatch } from "@contexts/QuotationContext";
 
-function ColorContent() {
+export default function ColorContent() {
   const quotationDispatch = useQuotationDispatch();
 
   const onClickHandler = (index: number) => {
@@ -17,7 +17,7 @@ function ColorContent() {
   };
 
   return (
-    <Container>
+    <Flex $flexDirection="column">
       <CategoryList
         categories={["외장색상", "내장색상"]}
         onClickHandler={(index) => onClickHandler(index as number)}
@@ -25,15 +25,6 @@ function ColorContent() {
         $switch={"colors"}
       />
       <ColorWrapper />
-    </Container>
+    </Flex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
-`;
-
-export default ColorContent;

--- a/FE-MyCarMaster/src/components/Main/view/ColorView/ColorWrapper.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/ColorView/ColorWrapper.tsx
@@ -1,13 +1,11 @@
-import { useQuotationState } from "../../../../contexts/QuotationContext";
+import { useQuotationState } from "@contexts/QuotationContext";
 import ExteriorColorView from "./ExteriorColorView";
 import InteriorColorView from "./InteriorColorView";
 
-function ColorWrapper() {
+export default function ColorWrapper() {
   const { navigationId } = useQuotationState();
 
   if (navigationId === 4) return <ExteriorColorView />;
   if (navigationId === 5) return <InteriorColorView />;
   return <></>;
 }
-
-export default ColorWrapper;

--- a/FE-MyCarMaster/src/components/Main/view/ColorView/ExteriorColorView.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/ColorView/ExteriorColorView.tsx
@@ -1,17 +1,17 @@
-import styled from "styled-components";
+import { useEffect } from "react";
+import { Flex, Image } from "@styles/core.style";
 import {
   useCarPaintDispatch,
   useCarPaintState,
-} from "../../../../contexts/CarPaintContext";
+} from "@contexts/CarPaintContext";
 import {
   useQuotationDispatch,
   useQuotationState,
-} from "../../../../contexts/QuotationContext";
-import { ExteriorColors } from "../../../../types/carpaint.types";
-import { useTrimState } from "../../../../contexts/TrimContext";
-import useFetch from "../../../../hooks/useFetch";
-import { useEffect } from "react";
-// import CarRotation from "../../../common/CarRotation/CarRotation";
+} from "@contexts/QuotationContext";
+import { useTrimState } from "@contexts/TrimContext";
+import { ExteriorColors } from "types/carpaint.types";
+import useFetch from "@hooks/useFetch";
+// import CarRotation from "@common/index";
 
 interface FetchExteriorProps extends ExteriorColors {
   result: {
@@ -19,7 +19,7 @@ interface FetchExteriorProps extends ExteriorColors {
   };
 }
 
-function ExteriorColorView() {
+export default function ExteriorColorView() {
   const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
 
   const { trimId } = useTrimState();
@@ -63,26 +63,19 @@ function ExteriorColorView() {
   if (!exteriorList?.length) return null;
 
   return (
-    exteriorList?.length && (
-      <ExteriorColorImg
-        src={
-          exteriorList.find((exterior) => exterior.id === exteriorId)
-            ?.coloredImgUrl
-        }
-      />
-      // <CarRotation $isQuotation={false} />
-    )
+    <Flex>
+      {exteriorList?.length && (
+        <Image
+          $width="100%"
+          $height="25rem"
+          $objectFit="cover"
+          src={
+            exteriorList.find((exterior) => exterior.id === exteriorId)
+              ?.coloredImgUrl
+          }
+        />
+        // <CarRotation $isQuotation={false} />
+      )}
+    </Flex>
   );
 }
-
-const ExteriorColorImg = styled.img`
-  width: 100%;
-  max-width: 50rem;
-  margin: 0 auto;
-  height: 100%;
-
-  object-fit: scale-down;
-  object-position: center;
-`;
-
-export default ExteriorColorView;

--- a/FE-MyCarMaster/src/components/Main/view/ColorView/InteriorColorView.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/ColorView/InteriorColorView.tsx
@@ -1,16 +1,16 @@
-import { styled } from "styled-components";
+import { useEffect } from "react";
+import { Flex, Image } from "@styles/core.style";
 import {
   useCarPaintDispatch,
   useCarPaintState,
-} from "../../../../contexts/CarPaintContext";
+} from "@contexts/CarPaintContext";
 import {
   useQuotationDispatch,
   useQuotationState,
-} from "../../../../contexts/QuotationContext";
-import { InteriorColors } from "../../../../types/carpaint.types";
-import useFetch from "../../../../hooks/useFetch";
-import { useTrimState } from "../../../../contexts/TrimContext";
-import { useEffect } from "react";
+} from "@contexts/QuotationContext";
+import { useTrimState } from "@contexts/TrimContext";
+import { InteriorColors } from "types/carpaint.types";
+import useFetch from "@hooks/useFetch";
 
 interface FetchInteriorProps extends InteriorColors {
   result: {
@@ -18,7 +18,7 @@ interface FetchInteriorProps extends InteriorColors {
   };
 }
 
-function InteriorColorView() {
+export default function InteriorColorView() {
   const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
 
   const { trimId } = useTrimState();
@@ -61,27 +61,19 @@ function InteriorColorView() {
   if (!interiorList?.length) return null;
 
   return (
-    <>
+    <Flex>
       {interiorList?.length && (
-        <InteriorColorImg
+        <Image
+          $width="100%"
+          $height="25rem"
+          $padding="1rem"
+          $objectFit="cover"
           src={
             interiorList.find((interior) => interior.id === interiorId)
               ?.coloredImgUrl
           }
         />
       )}
-    </>
+    </Flex>
   );
 }
-
-const InteriorColorImg = styled.img`
-  width: 100%;
-  max-width: 50rem;
-  margin: 0 auto;
-  height: 100%;
-
-  object-fit: scale-down;
-  object-position: center;
-`;
-
-export default InteriorColorView;

--- a/FE-MyCarMaster/src/components/Main/view/DetailModelContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/DetailModelContent.tsx
@@ -1,9 +1,9 @@
-import { styled } from "styled-components";
-import CategoryList from "../../common/CategoryList/CategoryList";
+import { Flex } from "@styles/core.style";
+import { CategoryList } from "@common/index";
 import DetailModelWrapper from "./DetailModelView/DetailModelWrapper";
-import { useQuotationDispatch } from "../../../contexts/QuotationContext";
+import { useQuotationDispatch } from "@contexts/QuotationContext";
 
-function DetailModelContent() {
+export default function DetailModelContent() {
   const quotationDispatch = useQuotationDispatch();
 
   const onClickHandler = (index: number) => {
@@ -16,7 +16,7 @@ function DetailModelContent() {
     });
   };
   return (
-    <Container>
+    <Flex $flexDirection="column">
       <CategoryList
         categories={["엔진", "구동방식", "바디타입"]}
         onClickHandler={(index) => onClickHandler(index as number)}
@@ -24,14 +24,6 @@ function DetailModelContent() {
         $switch={"detail"}
       />
       <DetailModelWrapper />
-    </Container>
+    </Flex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-`;
-
-export default DetailModelContent;

--- a/FE-MyCarMaster/src/components/Main/view/DetailModelView/BodyTypeView.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/DetailModelView/BodyTypeView.tsx
@@ -1,16 +1,13 @@
-import { styled } from "styled-components";
-import {
-  useDetailDispatch,
-  useDetailState,
-} from "../../../../contexts/DetailContext";
-import { BodyTypes } from "../../../../types/detail.types";
+import { useEffect } from "react";
+import { Flex, Image } from "@styles/core.style";
+import { useDetailDispatch, useDetailState } from "@contexts/DetailContext";
 import {
   useQuotationDispatch,
   useQuotationState,
-} from "../../../../contexts/QuotationContext";
-import { useModelState } from "../../../../contexts/ModelContext";
-import useFetch from "../../../../hooks/useFetch";
-import { useEffect } from "react";
+} from "@contexts/QuotationContext";
+import { useModelState } from "@contexts/ModelContext";
+import { BodyTypes } from "types/detail.types";
+import useFetch from "@hooks/useFetch";
 
 interface FetchBodyTypeProps extends BodyTypes {
   result: {
@@ -18,7 +15,7 @@ interface FetchBodyTypeProps extends BodyTypes {
   };
 }
 
-function BodyTypeView() {
+export default function BodyTypeView() {
   const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
 
   const { modelId } = useModelState();
@@ -61,22 +58,19 @@ function BodyTypeView() {
   if (!bodyTypeList?.length) return null;
 
   return (
-    bodyTypeList?.length && (
-      <BodyTypeImg
-        src={bodyTypeList.find((item) => item.id === bodyTypeId)?.imgUrl}
-      />
-    )
+    <Flex $justifyContent="flex-start" $alignItems="center">
+      {bodyTypeList?.length && (
+        <Image
+          $width="100%"
+          $height="25rem"
+          $objectFit="contain"
+          $margin="1rem"
+          $shadow={
+            "rgba(0, 0, 0, 0.07) 0px 1px 1px, rgba(0, 0, 0, 0.07) 0px 2px 2px, rgba(0, 0, 0, 0.07) 0px 4px 4px, rgba(0, 0, 0, 0.07) 0px 8px 8px, rgba(0, 0, 0, 0.07) 0px 16px 16px;"
+          }
+          src={bodyTypeList.find((item) => item.id === bodyTypeId)?.imgUrl}
+        />
+      )}
+    </Flex>
   );
 }
-
-const BodyTypeImg = styled.img`
-  width: 100%;
-  max-width: 40rem;
-  margin: 0 auto;
-  height: 100%;
-
-  object-fit: scale-down;
-  object-position: center;
-`;
-
-export default BodyTypeView;

--- a/FE-MyCarMaster/src/components/Main/view/DetailModelView/DetailModelWrapper.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/DetailModelView/DetailModelWrapper.tsx
@@ -1,14 +1,10 @@
-import EngineView from "./EngineView";
-import WheelDriveView from "./WheelDriveView";
-import BodyTypeView from "./BodyTypeView";
-import { useQuotationState } from "../../../../contexts/QuotationContext";
+import { EngineView, WheelDriveView, BodyTypeView } from "./index";
+import { useQuotationState } from "@contexts/QuotationContext";
 
-function DetailModelWrapper() {
+export default function DetailModelWrapper() {
   const { navigationId } = useQuotationState();
   if (navigationId === 1) return <EngineView />;
   if (navigationId === 2) return <WheelDriveView />;
   if (navigationId === 3) return <BodyTypeView />;
   return <></>;
 }
-
-export default DetailModelWrapper;

--- a/FE-MyCarMaster/src/components/Main/view/DetailModelView/EngineView.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/DetailModelView/EngineView.tsx
@@ -1,17 +1,14 @@
-import { styled } from "styled-components";
-import GraphList from "../../../common/Graph/GraphList";
-import {
-  useDetailDispatch,
-  useDetailState,
-} from "../../../../contexts/DetailContext";
-import { Engines } from "../../../../types/detail.types";
-import { useTrimState } from "../../../../contexts/TrimContext";
+import { useEffect } from "react";
+import { Flex, Image } from "@styles/core.style";
+import { GraphList } from "@common/index";
+import { useDetailDispatch, useDetailState } from "@contexts/DetailContext";
 import {
   useQuotationDispatch,
   useQuotationState,
-} from "../../../../contexts/QuotationContext";
-import useFetch from "../../../../hooks/useFetch";
-import { useEffect } from "react";
+} from "@contexts/QuotationContext";
+import { Engines } from "types/detail.types";
+import { useTrimState } from "@contexts/TrimContext";
+import useFetch from "@hooks/useFetch";
 
 interface FetchEngineProps extends Engines {
   result: {
@@ -19,7 +16,7 @@ interface FetchEngineProps extends Engines {
   };
 }
 
-function EngineView() {
+export default function EngineView() {
   const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
 
   const { trimId } = useTrimState();
@@ -59,41 +56,21 @@ function EngineView() {
     }
   }, [data]);
 
-  if (!engineList?.length) return <Container></Container>;
+  if (!engineList?.length) return <Flex></Flex>;
 
   return (
-    <Container>
+    <Flex $justifyContent="space-between" $gap="5rem" $alignItems="center">
       {engineList?.length && (
-        <EngineImg
+        <Image
+          $width="50%"
+          $height="20rem"
+          $objectFit="contain"
+          $shadow={"0 0 10px #000"}
           src={engineList.find((engine) => engine.id === engineId)?.imgUrl}
           alt="엔진 이미지"
         />
       )}
-      <EngineGraph>
-        <GraphList />
-      </EngineGraph>
-    </Container>
+      <GraphList />
+    </Flex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 2rem;
-  height: 100%;
-`;
-
-const EngineImg = styled.img`
-  flex: 1;
-  width: calc(100% / 2);
-  height: 25rem;
-  object-fit: contain;
-  object-position: center;
-`;
-
-const EngineGraph = styled.div`
-  flex: 1;
-`;
-
-export default EngineView;

--- a/FE-MyCarMaster/src/components/Main/view/DetailModelView/WheelDriveView.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/DetailModelView/WheelDriveView.tsx
@@ -1,16 +1,13 @@
-import { styled } from "styled-components";
-import {
-  useDetailDispatch,
-  useDetailState,
-} from "../../../../contexts/DetailContext";
-import { WheelDrives } from "../../../../types/detail.types";
-import { useTrimState } from "../../../../contexts/TrimContext";
+import { useEffect } from "react";
+import { Flex, Image } from "@styles/core.style";
+import { useDetailDispatch, useDetailState } from "@contexts/DetailContext";
+import { useTrimState } from "@contexts/TrimContext";
 import {
   useQuotationDispatch,
   useQuotationState,
-} from "../../../../contexts/QuotationContext";
-import useFetch from "../../../../hooks/useFetch";
-import { useEffect } from "react";
+} from "@contexts/QuotationContext";
+import { WheelDrives } from "types/detail.types";
+import useFetch from "@hooks/useFetch";
 
 interface FetchWheelDriveProps extends WheelDrives {
   result: {
@@ -18,7 +15,7 @@ interface FetchWheelDriveProps extends WheelDrives {
   };
 }
 
-function WheelDriveView() {
+export default function WheelDriveView() {
   const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
 
   const { trimId } = useTrimState();
@@ -61,24 +58,19 @@ function WheelDriveView() {
   if (!wheelDriveList?.length) return null;
 
   return (
-    wheelDriveList?.length && (
-      <WheelDriveImg
-        src={
-          wheelDriveList.find((wheelDrive) => wheelDrive.id === wheelDriveId)
-            ?.imgUrl
-        }
-      />
-    )
+    <Flex $justifyContent="flex-start" $alignItems="center">
+      {wheelDriveList?.length && (
+        <Image
+          $width="100%"
+          $height="25rem"
+          $objectFit="contain"
+          $margin="1rem"
+          src={
+            wheelDriveList.find((wheelDrive) => wheelDrive.id === wheelDriveId)
+              ?.imgUrl
+          }
+        />
+      )}
+    </Flex>
   );
 }
-
-const WheelDriveImg = styled.img`
-  width: 100%;
-  max-width: 40rem;
-  height: 100%;
-  margin: 0 auto;
-  object-fit: contain;
-  object-position: center;
-`;
-
-export default WheelDriveView;

--- a/FE-MyCarMaster/src/components/Main/view/OptionContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/OptionContent.tsx
@@ -15,6 +15,7 @@ interface FetchOptionsProps extends OptionType {
     options: OptionType[];
   };
 }
+
 export default function OptionContent() {
   const { optionList, optionId }: OptionState = useOptionState();
   const optionDispatch = useOptionDispatch();
@@ -81,6 +82,7 @@ export default function OptionContent() {
     target.style.animation = "1s hover_image_full ease-in-out forwards";
   };
 
+  const windowHeight = window.innerHeight;
   return (
     optionList?.length !== 0 && (
       <Flex
@@ -88,8 +90,10 @@ export default function OptionContent() {
         $justifyContent="flex-end"
         $alignItems="flex-start"
         $gap="5%"
+        $overflow="hidden"
       >
         <Flex
+          $maxHeight={windowHeight <= 950 ? "25rem" : ""}
           $justifyContent="space-between"
           $alignItems="flex-start"
           $gap="1rem"

--- a/FE-MyCarMaster/src/components/Main/view/OptionContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/OptionContent.tsx
@@ -1,25 +1,21 @@
-import { styled } from "styled-components";
-import CategoryList from "../../common/CategoryList/CategoryList";
-import OptionDescription from "../../common/OptionDescription/OptionDescription";
-import {
-  useOptionDispatch,
-  useOptionState,
-} from "../../../contexts/OptionContext";
-import useFetch from "../../../hooks/useFetch";
 import { useEffect } from "react";
-import { OptionType, OptionState } from "../../../types/options.types";
-import filterOptionCategory from "../../../utils/Option/filterOptionCategory";
-import { categories } from "../../../constants/Option.constants";
-import { useTrimState } from "../../../contexts/TrimContext";
-import { useDetailState } from "../../../contexts/DetailContext";
-import { useCarPaintState } from "../../../contexts/CarPaintContext";
+import { Flex, Image } from "@styles/core.style";
+import { CategoryList, OptionDescription } from "@common/index";
+import { useOptionDispatch, useOptionState } from "@contexts/OptionContext";
+import { useTrimState } from "@contexts/TrimContext";
+import { useDetailState } from "@contexts/DetailContext";
+import { useCarPaintState } from "@contexts/CarPaintContext";
+import filterOptionCategory from "@utils/Option/filterOptionCategory";
+import { categories } from "@constants/Option.constants";
+import { OptionType, OptionState } from "types/options.types";
+import useFetch from "@hooks/useFetch";
 
 interface FetchOptionsProps extends OptionType {
   result: {
     options: OptionType[];
   };
 }
-function OptionContent() {
+export default function OptionContent() {
   const { optionList, optionId }: OptionState = useOptionState();
   const optionDispatch = useOptionDispatch();
 
@@ -71,11 +67,40 @@ function OptionContent() {
     });
   };
 
+  const ResizeImageHandler = (e: React.MouseEvent<HTMLImageElement>) => {
+    const target = e.target as HTMLImageElement;
+
+    if (target.style.animation) {
+      target.style.animation = "1s hover_image_full_back ease-in-out forwards";
+
+      setTimeout(() => {
+        target.style.animation = "";
+      }, 1000);
+      return;
+    }
+    target.style.animation = "1s hover_image_full ease-in-out forwards";
+  };
+
   return (
     optionList?.length !== 0 && (
-      <Container>
-        <OptionContainer>
-          <OptionImg
+      <Flex
+        $flexDirection="column"
+        $justifyContent="flex-end"
+        $alignItems="flex-start"
+        $gap="5%"
+      >
+        <Flex
+          $justifyContent="space-between"
+          $alignItems="flex-start"
+          $gap="1rem"
+        >
+          <Image
+            $width="50%"
+            $height="85%"
+            $borderRadius="0 100% 100% 0"
+            $shadow="#222222 0 0 1rem"
+            $onHover={true}
+            onClick={(e) => ResizeImageHandler(e)}
             src={optionList.find((option) => option.id === optionId)?.imgUrl}
           />
           <OptionDescription
@@ -83,40 +108,13 @@ function OptionContent() {
               optionList.find((option) => option.id === optionId) as OptionType
             }
           />
-        </OptionContainer>
+        </Flex>
         <CategoryList
           categories={categories}
           onClickHandler={(index) => onClickHandler(index as number)}
           $switch={"option"}
         />
-      </Container>
+      </Flex>
     )
   );
 }
-
-const Container = styled.div`
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: end;
-  align-items: flex-start;
-  gap: 5%;
-`;
-
-const OptionContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-`;
-
-const OptionImg = styled.img`
-  max-width: 33rem;
-  width: 100%;
-  flex-shrink: 0;
-  padding-bottom: 15%;
-`;
-
-export default OptionContent;

--- a/FE-MyCarMaster/src/components/Main/view/TrimContent.tsx
+++ b/FE-MyCarMaster/src/components/Main/view/TrimContent.tsx
@@ -1,10 +1,10 @@
-import styled from "styled-components";
-import { useTrimDispatch, useTrimState } from "../../../contexts/TrimContext";
-import { useQuotationDispatch } from "../../../contexts/QuotationContext";
-import { Trims } from "../../../types/trim.types";
-import useFetch from "../../../hooks/useFetch";
-import { useModelState } from "../../../contexts/ModelContext";
 import { useEffect } from "react";
+import { Flex, Image } from "@styles/core.style";
+import { useTrimDispatch, useTrimState } from "@contexts/TrimContext";
+import { useQuotationDispatch } from "@contexts/QuotationContext";
+import { useModelState } from "@contexts/ModelContext";
+import { Trims } from "types/trim.types";
+import useFetch from "@hooks/useFetch";
 
 interface FetchTrimsProps extends Trims {
   result: {
@@ -12,7 +12,7 @@ interface FetchTrimsProps extends Trims {
   };
 }
 
-function TrimContent() {
+export default function TrimContent() {
   const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
 
   const { modelId } = useModelState();
@@ -45,15 +45,16 @@ function TrimContent() {
 
   if (!trimList?.length) return null;
 
-  return trimList?.length && <TrimImage src={trimList[trimId - 1].imgUrl} />;
+  return (
+    <Flex $justifyContent="flex-start" $alignItems="center">
+      {trimList?.length && (
+        <Image
+          $objectFit="contain"
+          $height="25rem"
+          $margin="0"
+          src={trimList[trimId - 1].imgUrl}
+        />
+      )}
+    </Flex>
+  );
 }
-
-const TrimImage = styled.img`
-  width: 100%;
-  min-width: 40rem;
-  height: 100%;
-  object-fit: contain;
-  object-position: center;
-`;
-
-export default TrimContent;

--- a/FE-MyCarMaster/src/components/common/index.ts
+++ b/FE-MyCarMaster/src/components/common/index.ts
@@ -3,7 +3,7 @@ export { default as Button } from "./Button/Button";
 export { default as TextButton } from "./Button/TextButton";
 export { default as CarRotation } from "./CarRotation/CarRotation";
 export { default as CategoryList } from "./CategoryList/CategoryList";
-export { default as CheckBox } from "./CheckBox/OptionCheckBox";
+export { default as OptionCheckBox } from "./CheckBox/OptionCheckBox";
 export { default as InnerColorBox } from "./ColorBox/InnerColorBox";
 export { default as OuterColorBox } from "./ColorBox/OuterColorBox";
 export { default as GraphList } from "./Graph/GraphList";

--- a/FE-MyCarMaster/src/contexts/CarPaintContext.tsx
+++ b/FE-MyCarMaster/src/contexts/CarPaintContext.tsx
@@ -4,7 +4,7 @@ import {
   CarPaintAction,
   ExteriorColors,
   InteriorColors,
-} from "../types/carpaint.types";
+} from "types/carpaint.types";
 
 const initialCarPaintState: CarPaintState = {
   exteriorId: 1,

--- a/FE-MyCarMaster/src/contexts/DetailContext.tsx
+++ b/FE-MyCarMaster/src/contexts/DetailContext.tsx
@@ -5,7 +5,7 @@ import {
   BodyTypes,
   DetailAction,
   DetailState,
-} from "../types/detail.types";
+} from "types/detail.types";
 
 const initialDetailState: DetailState = {
   engineId: 1,

--- a/FE-MyCarMaster/src/contexts/ModelContext.tsx
+++ b/FE-MyCarMaster/src/contexts/ModelContext.tsx
@@ -1,5 +1,5 @@
 import { useReducer, createContext, useContext } from "react";
-import { ModelState, ModelAction } from "../types/model.types";
+import { ModelState, ModelAction } from "types/model.types";
 
 const initialModelState: ModelState = {
   modelId: 1,

--- a/FE-MyCarMaster/src/contexts/OptionContext.tsx
+++ b/FE-MyCarMaster/src/contexts/OptionContext.tsx
@@ -1,5 +1,5 @@
 import { useReducer, createContext, useContext } from "react";
-import { OptionAction, OptionState, OptionType } from "../types/options.types";
+import { OptionAction, OptionState, OptionType } from "types/options.types";
 
 const initialOptionState: OptionState = {
   selectedOption: [],

--- a/FE-MyCarMaster/src/contexts/QuotationContext.tsx
+++ b/FE-MyCarMaster/src/contexts/QuotationContext.tsx
@@ -3,7 +3,7 @@ import {
   QuotationAction,
   QuotationState,
   QuotationType,
-} from "../types/quotation.types";
+} from "types/quotation.types";
 
 const initialQuotationState: QuotationState = {
   navigationId: 0,

--- a/FE-MyCarMaster/src/contexts/TrimContext.tsx
+++ b/FE-MyCarMaster/src/contexts/TrimContext.tsx
@@ -1,5 +1,5 @@
 import { useReducer, createContext, useContext } from "react";
-import { TrimAction, TrimState, Trims } from "../types/trim.types";
+import { TrimAction, TrimState, Trims } from "types/trim.types";
 
 const initialTrimState: TrimState = {
   trimId: 1,

--- a/FE-MyCarMaster/src/pages/Estimation.tsx
+++ b/FE-MyCarMaster/src/pages/Estimation.tsx
@@ -1,22 +1,13 @@
-import { Footer, Header, MainView } from "../components";
-import { styled } from "styled-components";
-import dark_logo from "../assets/images/dark_logo.svg";
+import { Header, MainView, Footer } from "@layout/index";
+import { Flex } from "@styles/core.style";
+import dark_logo from "@assets/images/dark_logo.svg";
 
-function Estimation() {
+export default function Estimation() {
   return (
-    <Container>
+    <Flex $flexDirection="column">
       <Header logo={dark_logo} isHome={false} />
       <MainView />
       <Footer />
-    </Container>
+    </Flex>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-`;
-
-export default Estimation;

--- a/FE-MyCarMaster/src/pages/Home.tsx
+++ b/FE-MyCarMaster/src/pages/Home.tsx
@@ -1,9 +1,8 @@
 import styled from "styled-components";
-import Button from "../components/common/Button/Button.tsx";
-import homeVideo from "../assets/video/homeVideo.mp4";
-import white_logo from "../assets/images/white_logo.svg";
-import ModelSelectView from "../components/Home/ModelSelectView.tsx";
-import { Header } from "../components/index.tsx";
+import { Button } from "@common/index";
+import homeVideo from "@assets/video/homeVideo.mp4";
+import white_logo from "@assets/images/white_logo.svg";
+import { ModelSelectView, Header } from "@layout/index";
 import { useState } from "react";
 
 type TextProp = {

--- a/FE-MyCarMaster/src/styles/core.style.ts
+++ b/FE-MyCarMaster/src/styles/core.style.ts
@@ -4,6 +4,7 @@ export interface FlexProps {
   $flexDirection?: "row" | "column";
   $width?: string;
   $height?: string;
+  $maxHeight?: string;
   $padding?: string;
   $position?: "relative" | "absolute";
   $margin?: string;
@@ -26,6 +27,7 @@ export const Flex = styled.div<FlexProps>`
   flex-direction: ${(props) => props.$flexDirection || "row"};
   width: ${(props) => props.$width || "100%"};
   height: ${(props) => props.$height || "100%"};
+  max-height: ${(props) => props.$maxHeight || "100%"};
   padding: ${(props) => props.$padding || "0"};
   margin: ${(props) => props.$margin || "0"};
   justify-content: ${(props) => props.$justifyContent || "flex-start"};

--- a/FE-MyCarMaster/src/styles/core.style.ts
+++ b/FE-MyCarMaster/src/styles/core.style.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 
-interface FlexProps {
+export interface FlexProps {
   $flexDirection?: "row" | "column";
   $width?: string;
   $height?: string;
   $padding?: string;
+  $position?: "relative" | "absolute";
   $margin?: string;
   $justifyContent?:
     | "center"
@@ -12,7 +13,12 @@ interface FlexProps {
     | "flex-end"
     | "space-between"
     | "space-around";
-  $alignItems?: string;
+  $alignItems?: "center" | "flex-start" | "flex-end";
+  $gap?: string;
+  $backgroundColor?: string;
+  $frame?: string;
+  $wrap?: boolean;
+  $overflow?: "hidden" | "scroll" | "auto";
 }
 
 export const Flex = styled.div<FlexProps>`
@@ -23,7 +29,12 @@ export const Flex = styled.div<FlexProps>`
   padding: ${(props) => props.$padding || "0"};
   margin: ${(props) => props.$margin || "0"};
   justify-content: ${(props) => props.$justifyContent || "flex-start"};
-  align-items: ${(props) => props.$alignItems || "center"};
+  align-items: ${(props) => props.$alignItems || "normal"};
+  gap: ${(props) => props.$gap || "0"};
+  background-color: ${(props) => props.$backgroundColor || "transparent"};
+  flex-wrap: ${(props) => (props.$wrap ? "wrap" : "nowrap")};
+  overflow: ${(props) => props.$overflow || "visible"};
+  position: ${(props) => props.$position || "static"};
 `;
 
 interface TextProps {
@@ -38,4 +49,76 @@ export const Text = styled.p<TextProps>`
   font-weight: ${(props) => props.$fontWeight || "normal"};
   color: ${(props) => props.$color || "#000"};
   text-align: ${(props) => props.$textAlign || "left"};
+`;
+
+interface ImageProps {
+  $width?: string;
+  $height?: string;
+  $margin?: string;
+  $padding?: string;
+  $objectFit?: "cover" | "contain" | "fill";
+  $shadow?: string;
+  $borderRadius?: string;
+  $onHover?: boolean;
+}
+
+export const Image = styled.img<ImageProps>`
+  width: ${(props) => props.$width || "100%"};
+  height: ${(props) => props.$height || "100%"};
+  object-fit: ${(props) => props.$objectFit || "cover"};
+  object-position: center;
+  margin: ${(props) => props.$margin || "auto"};
+  padding: ${(props) => props.$padding || "0"};
+  box-shadow: ${(props) => props.$shadow || "none"};
+
+  user-select: none;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+
+  ${(props) =>
+    props.$onHover &&
+    `
+    &:hover {
+      animation: 0.5s hover_image ease-in-out forwards;
+
+      @keyframes hover_image {
+        0% {
+          border-radius: ${props.$borderRadius || "0"};
+        }
+        100% {
+          border-radius: 0;
+        }
+      }
+    }
+    
+    &:not(:hover) {
+      animation: 1.5s hover_image_back ease-in-out forwards;
+
+      @keyframes hover_image_back {
+        0% {
+          border-radius: 0;
+        }
+        100% {
+          border-radius: ${props.$borderRadius || "0"};
+        }
+      }
+    }
+    `}
+  @keyframes hover_image_full {
+    0% {
+      border-radius: 0;
+    }
+    100% {
+      width: 100%;
+    }
+  }
+
+  @keyframes hover_image_full_back {
+    0% {
+      width: 100%;
+    }
+    100% {
+      width: 50%;
+    }
+  }
 `;


### PR DESCRIPTION
## 개요
- #357 

## 작업사항
- 모든 파일의 상대 경로 -> 절대 경로 지정
- 코어 컴포넌트 사용 (Flex, Image) 이하 옵션은 core.style.ts에 정의됨
- 일부 컴포넌트 디자인 개선

### 디자인 개선
1. 세부모델 size issue
  - 이 문제를 해결하기 위해 border를 두어 각기 다른 이미지를 어느정도 맞추어야 함.

> 변경 전
<img width="1726" alt="스크린샷 2023-08-22 오후 11 21 55" src="https://github.com/softeerbootcamp-2nd/H5-MyCarMaster/assets/82306066/8261a93a-e758-4677-b4d2-040457fc3988">

> 변경 후
<img width="1726" alt="스크린샷 2023-08-22 오후 11 21 47" src="https://github.com/softeerbootcamp-2nd/H5-MyCarMaster/assets/82306066/e35439fb-5793-40e2-9da3-75725443cbe1">

2. 옵션 아이템 description 량 편차가 큰편, 이미지 크기도 다른 문제
  - 이미지의 크기를 센터기준으로 일정 부분만 보여주고 펼치는 형식으로 전개하여 디자인 함.

<img width="1726" alt="스크린샷 2023-08-22 오후 11 24 52" src="https://github.com/softeerbootcamp-2nd/H5-MyCarMaster/assets/82306066/85ae298a-ec5c-4cb3-869d-deae02767f79">

https://github.com/softeerbootcamp-2nd/H5-MyCarMaster/assets/82306066/22040881-4f21-492c-a796-4404871d6889

3. 옵션 뷰 하단 스크롤 구현 -> 기존 기획

## Reference
-[Shadow ?!](https://getcssscan.com/css-box-shadow-examples)
