### PR TITLE
[FE-Bug] Font Recall 개선

### DIFF
--- a/FE-MyCarMaster/src/App.tsx
+++ b/FE-MyCarMaster/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { createElement } from "react";
 import { Flex } from "@styles/core.style";
 import { Routes, Route } from "react-router-dom";
+import GlobalStyle from "@styles/GlobalStyle.ts";
 import { ThemeProvider } from "styled-components";
 import { ModelProvider } from "@contexts/ModelContext";
 import { TrimProvider } from "@contexts/TrimContext";
@@ -9,7 +10,6 @@ import { CarPaintProvider } from "@contexts/CarPaintContext";
 import { OptionProvider } from "@contexts/OptionContext";
 import { QuotationProvider } from "@contexts/QuotationContext";
 import theme from "@styles/Theme";
-
 import {
   Home,
   Estimation,
@@ -17,6 +17,8 @@ import {
   WrittenQuotation,
   ConsultComplete,
 } from "@pages/index";
+import { useFonts } from "@hooks/useFonts";
+import { fonts } from "@constants/Font.constants";
 
 type ContextProvider = React.ComponentType<{ children: React.ReactNode }>;
 
@@ -36,32 +38,36 @@ const AppProvider = ({
   );
 
 function App() {
+  useFonts(fonts);
   return (
-    <ThemeProvider theme={theme}>
-      <AppProvider
-        providers={[
-          ModelProvider,
-          TrimProvider,
-          DetailProvider,
-          CarPaintProvider,
-          OptionProvider,
-          QuotationProvider,
-        ]}
-      >
-        <Flex>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/estimation" element={<Estimation />} />
-            <Route path="/quotation" element={<Quotation />} />
-            <Route
-              path="/estimates/:estimateId"
-              element={<WrittenQuotation />}
-            />
-            <Route path="/consult-complete" element={<ConsultComplete />} />
-          </Routes>
-        </Flex>
-      </AppProvider>
-    </ThemeProvider>
+    <>
+      <GlobalStyle />
+      <ThemeProvider theme={theme}>
+        <AppProvider
+          providers={[
+            ModelProvider,
+            TrimProvider,
+            DetailProvider,
+            CarPaintProvider,
+            OptionProvider,
+            QuotationProvider,
+          ]}
+        >
+          <Flex>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/estimation" element={<Estimation />} />
+              <Route path="/quotation" element={<Quotation />} />
+              <Route
+                path="/estimates/:estimateId"
+                element={<WrittenQuotation />}
+              />
+              <Route path="/consult-complete" element={<ConsultComplete />} />
+            </Routes>
+          </Flex>
+        </AppProvider>
+      </ThemeProvider>
+    </>
   );
 }
 

--- a/FE-MyCarMaster/src/constants/Font.constants.ts
+++ b/FE-MyCarMaster/src/constants/Font.constants.ts
@@ -1,0 +1,23 @@
+export const fonts = [
+  {
+    family: "HyundaiSansBold",
+    url: "./fonts/HyundaiSansHeadKRBold.woff2",
+    options: {
+      fontDisplay: "swap",
+    },
+  },
+  {
+    family: "HyundaiSansMedium",
+    url: "./fonts/HyundaiSansHeadKRMedium.woff2",
+    options: {
+      fontDisplay: "swap",
+    },
+  },
+  {
+    family: "HyundaiSansRegular",
+    url: "./fonts/HyundaiSansHeadKRRegular.woff2",
+    options: {
+      fontDisplay: "swap",
+    },
+  },
+];

--- a/FE-MyCarMaster/src/hooks/useFonts.ts
+++ b/FE-MyCarMaster/src/hooks/useFonts.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+type FontFaceType = {
+  family: string;
+  url: string;
+  options: {
+    fontDisplay: string;
+  };
+};
+
+function useFonts(fonts: FontFaceType[]) {
+  const [fontFaces] = useState(
+    fonts.map((font) => {
+      return new FontFace(font.family, `url(${font.url})`, font.options);
+    })
+  );
+
+  async function loadFontFace(fontFace) {
+    const loadedFont = await fontFace.load();
+    document.fonts.add(loadedFont);
+  }
+
+  useEffect(() => {
+    fontFaces.forEach((fontFace, index) => {
+      loadFontFace(fontFace);
+    });
+  }, [fontFaces]);
+}
+
+export { useFonts };

--- a/FE-MyCarMaster/src/main.tsx
+++ b/FE-MyCarMaster/src/main.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
-import GlobalStyle from "./styles/GlobalStyle.ts";
 import { BrowserRouter } from "react-router-dom";
 import "./main.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <GlobalStyle />
     <BrowserRouter>
       <App />
     </BrowserRouter>


### PR DESCRIPTION
## 개요
- #385 
- #382 도중 생긴 에러입니다. Font가 지속적으로 렌더링마다 불러오는 현상이 발생하였습니다.

https://github.com/softeerbootcamp-2nd/H5-MyCarMaster/assets/82306066/216fe536-7795-4c9c-9076-d930aa1d40f9

- 다음 이슈는 컴포넌트 깜빡임 현상을 야기합니다.
- styled-component 

## 작업사항
- useFonts 훅을 사용하여, font를 동적으로 body에 저장
- globalStyle에 import된 폰트 제거

## Reference
- [loadFont, FontFace Class](https://medium.com/@wfercanas/load-fonts-on-demand-with-react-206ce12174c0)