### PR TITLE
[Refactor] 거리 조회 쿼리 튜닝

### DIFF
--- a/BE-MyCarMaster/build.gradle
+++ b/BE-MyCarMaster/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     // monitoring
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    implementation 'org.hibernate:hibernate-spatial'
 }
 
 tasks.named('test') {

--- a/BE-MyCarMaster/build.gradle
+++ b/BE-MyCarMaster/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 
-
     // aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/agency/entity/AgencyEntity.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/agency/entity/AgencyEntity.java
@@ -1,20 +1,18 @@
 package softeer.be_my_car_master.infrastructure.jpa.agency.entity;
 
-import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
+
+import org.locationtech.jts.geom.Point;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import softeer.be_my_car_master.domain.agency.Agency;
-import softeer.be_my_car_master.infrastructure.jpa.car_master.entity.CarMasterEntity;
 
 @Entity
 @Getter
@@ -37,6 +35,9 @@ public class AgencyEntity {
 
 	@Column(name = "gu", nullable = false)
 	private String gu;
+
+	@Column(name = "points")
+	private Point points;
 
 	public Agency toAgency() {
 		return Agency.builder()

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/agency/repository/AgencyJpaRepository.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/agency/repository/AgencyJpaRepository.java
@@ -11,7 +11,7 @@ import softeer.be_my_car_master.infrastructure.jpa.agency.entity.AgencyEntity;
 public interface AgencyJpaRepository extends JpaRepository<AgencyEntity, Long> {
 
 	@Query(value = "SELECT * FROM agency "
-		+ "WHERE ST_Contains(ST_Buffer(ST_GeomFromText(CONCAT('Point(', :lat, ' ', :long, ')'), 0), 0.02), points)",
+		+ "WHERE ST_Contains(ST_Buffer(ST_GeomFromText(CONCAT('Point(', :lat, ' ', :long, ')'), 0), 0.021), points)",
 		nativeQuery = true)
 	List<AgencyEntity> findAllByLocation(@Param("lat") Double latitude, @Param("long") Double longitude);
 

--- a/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/agency/repository/AgencyJpaRepository.java
+++ b/BE-MyCarMaster/src/main/java/softeer/be_my_car_master/infrastructure/jpa/agency/repository/AgencyJpaRepository.java
@@ -10,17 +10,10 @@ import softeer.be_my_car_master.infrastructure.jpa.agency.entity.AgencyEntity;
 
 public interface AgencyJpaRepository extends JpaRepository<AgencyEntity, Long> {
 
-	@Query(value = "SELECT a.* "
-		+ "FROM agency a "
-		+ "WHERE a.id IN ("
-		+ "SELECT id "
-		+ "FROM agency "
-		+ "WHERE ST_Distance_Sphere(POINT(:longitude, :latitude), POINT(longitude, latitude)) < 2000"
-		+ ")",
+	@Query(value = "SELECT * FROM agency "
+		+ "WHERE ST_Contains(ST_Buffer(ST_GeomFromText(CONCAT('Point(', :lat, ' ', :long, ')'), 0), 0.02), points)",
 		nativeQuery = true)
-	List<AgencyEntity> findAllByLocation(
-		@Param("latitude") Double latitude,
-		@Param("longitude") Double longitude);
+	List<AgencyEntity> findAllByLocation(@Param("lat") Double latitude, @Param("long") Double longitude);
 
 	List<AgencyEntity> findAllByGu(String gu);
 }

--- a/BE-MyCarMaster/src/main/resources/application-domain.yml
+++ b/BE-MyCarMaster/src/main/resources/application-domain.yml
@@ -12,13 +12,14 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
     show-sql: true
     open-in-view : false
+    database-platform: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect
 
   redis:
     url: redis


### PR DESCRIPTION
## 개요
- #373 

## 작업사항
- 거리 조회는 상당히 빈번하게 조회하는 API. 이전에는 거리 계산시 full table scan 발생 (100ms) -> 따라서 쿼리 튜닝 여지 존재
- 기존 조회 쿼리 (ST_Distance_Sphere)에서는 spatial_index 적용이 되지않음.
- 이에 따라 ST_Contains 함수를 통해 조회하는 방식으로 변경하고, index 설정
- 최소 시간 20ms ~ 최대 40ms -> 약 3~5배 성능 개선

## Reference
- [spatial index 적용](https://velog.io/@noh0907/MySQL-%EC%A2%8C%ED%91%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EA%B0%80%EC%A0%B8%EC%98%A4%EA%B8%B0-Spatial-Index-%ED%99%9C%EC%9A%A9%ED%95%98%EA%B8%B0)
